### PR TITLE
Stabilization Phase 8 — mode normalizer + dedup mutex + pending-order cap with rank replacement

### DIFF
--- a/tcode/alpha_control_center/src/pages/Dashboard.tsx
+++ b/tcode/alpha_control_center/src/pages/Dashboard.tsx
@@ -1731,11 +1731,7 @@ function fillWindowLabel(): string {
 
 const PendingOrderModal = ({ order, onClose }: { order: PendingOrder; onClose: () => void }) => {
     // Approximate rank breakdown for display (mirrors computeRank in subscriber.go).
-    const rankBreakdown = (() => {
-        if (order.rank == null) return null;
-        const conf = order.rank; // we don't have decomposed components, show total
-        return { total: order.rank };
-    })();
+    const rankBreakdown = order.rank != null ? { total: order.rank } : null;
 
     return (
         <div className="modal-overlay" onClick={onClose} role="dialog" aria-modal="true" aria-label="Pending Order Detail">

--- a/tcode/alpha_control_center/src/pages/Dashboard.tsx
+++ b/tcode/alpha_control_center/src/pages/Dashboard.tsx
@@ -1685,13 +1685,23 @@ interface PendingOrder {
     filled_qty: number;
     avg_fill_price: number;
     timestamp: string;
+    rank?: number;  // signal rank [0,1] from pending cap tracker
 }
 
 interface PendingOrdersResponse {
     active: PendingOrder[];
     cancelled: PendingOrder[];
     source: string;
+    cap?: number;   // MAX_PENDING_ORDERS value
     error?: string;
+}
+
+interface CapEvent {
+    ts: string;
+    kind: 'REPLACE' | 'REJECT-CAP';
+    cancelled_id: number;
+    cancelled_rank: number;
+    incoming_rank: number;
 }
 
 function orderLabel(o: PendingOrder): string {
@@ -1719,48 +1729,72 @@ function fillWindowLabel(): string {
     return 'fills next Monday 9:30 AM ET';
 }
 
-const PendingOrderModal = ({ order, onClose }: { order: PendingOrder; onClose: () => void }) => (
-    <div className="modal-overlay" onClick={onClose} role="dialog" aria-modal="true" aria-label="Pending Order Detail">
-        <div className="modal-card fill-drill" onClick={e => e.stopPropagation()}>
-            <div className="modal-header">
-                <span className="modal-title">⏳ PENDING ORDER #{order.orderId}</span>
-                <button className="modal-close" onClick={onClose} aria-label="Close pending order detail">✕</button>
-            </div>
-            <div className="fill-drill-body pending-order-modal-body">
-                <div className={`fill-pnl-banner ${order.status === 'Filled' ? 'win' : ''}`}
-                     style={{ background: 'rgba(139,92,246,0.12)', borderColor: 'rgba(139,92,246,0.4)' }}>
-                    <span className="fill-pnl-label" style={{ color: '#c9d1d9' }}>{order.action} {orderLabel(order)}</span>
-                    <span className="fill-pnl-value" style={{ color: '#e6a200' }}>{order.status}</span>
+const PendingOrderModal = ({ order, onClose }: { order: PendingOrder; onClose: () => void }) => {
+    // Approximate rank breakdown for display (mirrors computeRank in subscriber.go).
+    const rankBreakdown = (() => {
+        if (order.rank == null) return null;
+        const conf = order.rank; // we don't have decomposed components, show total
+        return { total: order.rank };
+    })();
+
+    return (
+        <div className="modal-overlay" onClick={onClose} role="dialog" aria-modal="true" aria-label="Pending Order Detail">
+            <div className="modal-card fill-drill" onClick={e => e.stopPropagation()}>
+                <div className="modal-header">
+                    <span className="modal-title">⏳ PENDING ORDER #{order.orderId}</span>
+                    <button className="modal-close" onClick={onClose} aria-label="Close pending order detail">✕</button>
                 </div>
-                <div className="fill-section">
-                    <div className="fill-section-title">Order Detail</div>
-                    <div className="fill-grid">
-                        <div className="fill-row"><span>Order ID</span><span>#{order.orderId}</span></div>
-                        <div className="fill-row"><span>Status</span><span style={{ color: '#e6a200', fontWeight: 700 }}>{order.status}</span></div>
-                        <div className="fill-row"><span>Symbol</span><span>{order.symbol}</span></div>
-                        <div className="fill-row"><span>Action</span><span>{order.action}</span></div>
-                        <div className="fill-row"><span>Option Type</span><span>{order.option_type || '—'}</span></div>
-                        <div className="fill-row"><span>Strike</span><span>{order.strike > 0 ? `$${order.strike}` : '—'}</span></div>
-                        <div className="fill-row"><span>Expiry</span><span>{order.expiry || '—'}</span></div>
-                        <div className="fill-row"><span>Qty</span><span>{order.qty}</span></div>
-                        <div className="fill-row"><span>Limit Price</span><span>{order.limit_price > 0 ? formatUSD(order.limit_price) : '—'}</span></div>
-                        <div className="fill-row"><span>Filled Qty</span><span>{order.filled_qty}</span></div>
-                        <div className="fill-row"><span>Avg Fill Price</span><span>{order.avg_fill_price > 0 ? formatUSD(order.avg_fill_price) : '—'}</span></div>
-                        <div className="fill-row"><span>Submitted At</span><span>{order.timestamp ? new Date(order.timestamp).toLocaleString() : '—'}</span></div>
+                <div className="fill-drill-body pending-order-modal-body">
+                    <div className={`fill-pnl-banner ${order.status === 'Filled' ? 'win' : ''}`}
+                         style={{ background: 'rgba(139,92,246,0.12)', borderColor: 'rgba(139,92,246,0.4)' }}>
+                        <span className="fill-pnl-label" style={{ color: '#c9d1d9' }}>{order.action} {orderLabel(order)}</span>
+                        <span className="fill-pnl-value" style={{ color: '#e6a200' }}>{order.status}</span>
                     </div>
-                </div>
-                <div className="fill-section">
-                    <div className="fill-section-title">Fill Window</div>
-                    <div style={{ fontSize: '0.78rem', color: '#58a6ff', padding: '4px 0' }}>{fillWindowLabel()}</div>
-                </div>
-                <div className="fill-section">
-                    <div className="fill-section-title">Raw IBKR State</div>
-                    <div className="raw-order-block">{JSON.stringify(order, null, 2)}</div>
+                    <div className="fill-section">
+                        <div className="fill-section-title">Order Detail</div>
+                        <div className="fill-grid">
+                            <div className="fill-row"><span>Order ID</span><span>#{order.orderId}</span></div>
+                            <div className="fill-row"><span>Status</span><span style={{ color: '#e6a200', fontWeight: 700 }}>{order.status}</span></div>
+                            <div className="fill-row"><span>Symbol</span><span>{order.symbol}</span></div>
+                            <div className="fill-row"><span>Action</span><span>{order.action}</span></div>
+                            <div className="fill-row"><span>Option Type</span><span>{order.option_type || '—'}</span></div>
+                            <div className="fill-row"><span>Strike</span><span>{order.strike > 0 ? `$${order.strike}` : '—'}</span></div>
+                            <div className="fill-row"><span>Expiry</span><span>{order.expiry || '—'}</span></div>
+                            <div className="fill-row"><span>Qty</span><span>{order.qty}</span></div>
+                            <div className="fill-row"><span>Limit Price</span><span>{order.limit_price > 0 ? formatUSD(order.limit_price) : '—'}</span></div>
+                            <div className="fill-row"><span>Filled Qty</span><span>{order.filled_qty}</span></div>
+                            <div className="fill-row"><span>Avg Fill Price</span><span>{order.avg_fill_price > 0 ? formatUSD(order.avg_fill_price) : '—'}</span></div>
+                            <div className="fill-row"><span>Submitted At</span><span>{order.timestamp ? new Date(order.timestamp).toLocaleString() : '—'}</span></div>
+                        </div>
+                    </div>
+                    {rankBreakdown && (
+                        <div className="fill-section">
+                            <div className="fill-section-title">Signal Rank</div>
+                            <div className="fill-grid">
+                                <div className="fill-row">
+                                    <span>Overall Rank</span>
+                                    <span style={{ color: '#58a6ff', fontWeight: 700 }}>{rankBreakdown.total.toFixed(3)}</span>
+                                </div>
+                                <div className="fill-row" style={{ fontSize: '0.72rem', color: '#8b949e' }}>
+                                    <span>Formula</span>
+                                    <span>confidence×0.5 + roi×0.3 + recency×0.2</span>
+                                </div>
+                            </div>
+                        </div>
+                    )}
+                    <div className="fill-section">
+                        <div className="fill-section-title">Fill Window</div>
+                        <div style={{ fontSize: '0.78rem', color: '#58a6ff', padding: '4px 0' }}>{fillWindowLabel()}</div>
+                    </div>
+                    <div className="fill-section">
+                        <div className="fill-section-title">Raw IBKR State</div>
+                        <div className="raw-order-block">{JSON.stringify(order, null, 2)}</div>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
-);
+    );
+};
 
 // ============================================================
 //  Column B: Pending Orders
@@ -1768,22 +1802,57 @@ const PendingOrderModal = ({ order, onClose }: { order: PendingOrder; onClose: (
 const PendingOrdersPanel = ({
     orders,
     source,
+    capEvents,
+    replacementToast,
 }: {
     orders: PendingOrdersResponse | null;
     source: string;
+    capEvents: CapEvent[];
+    replacementToast: CapEvent | null;
 }) => {
     const [selectedOrder, setSelectedOrder] = useState<PendingOrder | null>(null);
     const [cancelledOpen, setCancelledOpen] = useState(false);
+    const [eventsOpen, setEventsOpen] = useState(false);
 
     const active    = orders?.active    ?? [];
     const cancelled = orders?.cancelled ?? [];
+    const cap       = orders?.cap       ?? 2;
     const hasError  = !!orders?.error;
+
+    // Header color: red at cap, amber at cap-1, green below
+    const capColor = active.length >= cap
+        ? '#f85149'
+        : active.length >= cap - 1
+        ? '#e6a200'
+        : '#3fb950';
 
     return (
         <>
             {selectedOrder && (
                 <PendingOrderModal order={selectedOrder} onClose={() => setSelectedOrder(null)} />
             )}
+
+            {/* Replacement toast */}
+            {replacementToast && (
+                <div
+                    role="status"
+                    aria-live="polite"
+                    data-testid="cap-replacement-toast"
+                    style={{
+                        position: 'fixed', bottom: 24, right: 24, zIndex: 9999,
+                        background: 'rgba(88,166,255,0.15)',
+                        border: '1px solid rgba(88,166,255,0.5)',
+                        borderRadius: 8, padding: '10px 16px',
+                        fontSize: '0.78rem', color: '#c9d1d9', maxWidth: 320,
+                    }}
+                >
+                    {replacementToast.kind === 'REPLACE'
+                        ? `Better signal replaced orderId=${replacementToast.cancelled_id} (rank ${replacementToast.cancelled_rank.toFixed(2)} → ${replacementToast.incoming_rank.toFixed(2)})`
+                        : `Signal rejected — cap full (rank ${replacementToast.incoming_rank.toFixed(2)} below cutoff ${replacementToast.cancelled_rank.toFixed(2)})`
+                    }
+                </div>
+            )}
+
             <div className="dash-col card" role="region" aria-label="Pending Orders — queued IBKR orders">
                 <div className="section-header">
                     <Tooltip text="Orders submitted to IBKR but not yet filled. Click any row for full state.">
@@ -1792,7 +1861,14 @@ const PendingOrdersPanel = ({
                         </span>
                     </Tooltip>
                     <div className="section-meta">
-                        <span className="inline-badge" aria-label={`${active.length} pending orders`}>{active.length}</span>
+                        {/* "Pending (N/max)" badge — color by saturation */}
+                        <span
+                            className="inline-badge"
+                            aria-label={`${active.length} of ${cap} pending orders`}
+                            style={{ color: capColor, border: `1px solid ${capColor}44`, background: `${capColor}11` }}
+                        >
+                            {active.length}/{cap}
+                        </span>
                         {source && source !== 'SIMULATION' && (
                             <span className="inline-badge" style={{ background: 'rgba(139,92,246,0.15)', color: '#a371f7' }}>
                                 {source.replace('IBKR_', '')}
@@ -1830,6 +1906,16 @@ const PendingOrdersPanel = ({
                                 </Tooltip>
                                 <span className="pending-status-badge">{o.status}</span>
                                 <span className="pending-order-id">#{o.orderId}</span>
+                                {/* Rank badge */}
+                                {o.rank != null && o.rank > 0 && (
+                                    <span
+                                        className="inline-badge"
+                                        title={`Signal rank: ${o.rank.toFixed(3)}`}
+                                        style={{ fontSize: '0.65rem', color: '#58a6ff', background: 'rgba(88,166,255,0.1)', border: '1px solid rgba(88,166,255,0.3)' }}
+                                    >
+                                        rank: {o.rank.toFixed(2)}
+                                    </span>
+                                )}
                             </div>
                             <div className="pending-order-detail">
                                 <span>×{o.qty}</span>
@@ -1865,6 +1951,41 @@ const PendingOrdersPanel = ({
                                     style={{ cursor: 'pointer' }}
                                 >
                                     #{o.orderId} {o.action} {orderLabel(o)} — Cancelled
+                                </div>
+                            ))}
+                        </div>
+                    )}
+
+                    {/* Cap event feed — last 10 REPLACE / REJECT-CAP events */}
+                    {capEvents.length > 0 && (
+                        <div className="cancelled-accordion" style={{ marginTop: 8 }}>
+                            <div
+                                className="cancelled-accordion-header"
+                                onClick={() => setEventsOpen(v => !v)}
+                                role="button"
+                                tabIndex={0}
+                                aria-expanded={eventsOpen}
+                                aria-label={`Cap events — ${capEvents.length} recent. Click to ${eventsOpen ? 'collapse' : 'expand'}.`}
+                                onKeyDown={e => e.key === 'Enter' && setEventsOpen(v => !v)}
+                            >
+                                <span>Cap events ({capEvents.length})</span>
+                                <span style={{ transform: eventsOpen ? 'rotate(90deg)' : 'none', transition: 'transform 0.15s' }}>▶</span>
+                            </div>
+                            {eventsOpen && capEvents.map((ev, i) => (
+                                <div
+                                    key={`${ev.ts}-${i}`}
+                                    style={{
+                                        padding: '4px 10px',
+                                        fontSize: '0.7rem',
+                                        color: ev.kind === 'REPLACE' ? '#3fb950' : '#e6a200',
+                                        borderBottom: '1px solid rgba(48,54,61,0.5)',
+                                    }}
+                                >
+                                    <span style={{ color: '#8b949e', marginRight: 6 }}>{new Date(ev.ts).toLocaleTimeString()}</span>
+                                    {ev.kind === 'REPLACE'
+                                        ? `[REPLACE] cancelled #${ev.cancelled_id} (rank ${ev.cancelled_rank.toFixed(2)}) → ${ev.incoming_rank.toFixed(2)}`
+                                        : `[REJECT-CAP] rank ${ev.incoming_rank.toFixed(2)} below ${ev.cancelled_rank.toFixed(2)}`
+                                    }
                                 </div>
                             ))}
                         </div>
@@ -2932,6 +3053,9 @@ const Dashboard = ({ brokerStatus, integrityRed = false }: { brokerStatus: Broke
     const [accountLoading, setAccountLoading] = useState(true);
     const [ibkrPositions, setIBKRPositions] = useState<IBKRPosition[]>([]);
     const [pendingOrders, setPendingOrders] = useState<PendingOrdersResponse | null>(null);
+    const [capEvents, setCapEvents] = useState<CapEvent[]>([]);
+    const [replacementToast, setReplacementToast] = useState<CapEvent | null>(null);
+    const prevCapEventsLenRef = useRef(0);
     const [simMode, setSimMode] = useState<string>('paper');
     const [scorecard, setScorecard] = useState<ModelScorecard[]>([]);
     const [scorecardLoading, setScorecardLoading] = useState(true);
@@ -2999,6 +3123,23 @@ const Dashboard = ({ brokerStatus, integrityRed = false }: { brokerStatus: Broke
         } catch { /* ignore — endpoint unavailable or gateway down */ }
     }, []);
 
+    // Fetch cap events (15s interval — in-memory, fast)
+    const fetchCapEvents = useCallback(async () => {
+        try {
+            const r = await fetch('/api/orders/cap-events');
+            if (!r.ok) return;
+            const data = await r.json() as { events: CapEvent[] };
+            const events: CapEvent[] = data.events ?? [];
+            setCapEvents(events);
+            // Show toast if a new event arrived since last poll
+            if (events.length > prevCapEventsLenRef.current && events.length > 0) {
+                setReplacementToast(events[0]);
+                setTimeout(() => setReplacementToast(null), 6000);
+            }
+            prevCapEventsLenRef.current = events.length;
+        } catch { /* ignore */ }
+    }, []);
+
     useEffect(() => {
         // Initial call handled by main stagger below
         const id = setInterval(fetchAccount, 10000);
@@ -3009,6 +3150,11 @@ const Dashboard = ({ brokerStatus, integrityRed = false }: { brokerStatus: Broke
         const id = setInterval(fetchPendingOrders, 30000);
         return () => clearInterval(id);
     }, [fetchPendingOrders]);
+
+    useEffect(() => {
+        const id = setInterval(fetchCapEvents, 15000);
+        return () => clearInterval(id);
+    }, [fetchCapEvents]);
 
     // Fetch scorecard + loss summary (60s interval)
     const fetchScorecard = useCallback(async () => {
@@ -3156,11 +3302,12 @@ const Dashboard = ({ brokerStatus, integrityRed = false }: { brokerStatus: Broke
         fetchAll();
         setTimeout(fetchAccount, 500);
         setTimeout(fetchPendingOrders, 2000);
+        setTimeout(fetchCapEvents, 2500);
         setTimeout(fetchScorecard, 1500);
         setTimeout(fetchIntel, 3000);
         const id = setInterval(fetchAll, 3000);
         return () => clearInterval(id);
-    }, [fetchAll, fetchPendingOrders]);
+    }, [fetchAll, fetchPendingOrders, fetchCapEvents]);
 
     return (
         <>
@@ -3243,6 +3390,8 @@ const Dashboard = ({ brokerStatus, integrityRed = false }: { brokerStatus: Broke
                 <PendingOrdersPanel
                     orders={pendingOrders}
                     source={pendingOrders?.source ?? ''}
+                    capEvents={capEvents}
+                    replacementToast={replacementToast}
                 />
                 <TradingFloor portfolio={portfolio} ibkrPositions={ibkrPositions} brokerStatus={brokerStatus} />
                 <ExecutionLog trades={trades} brokerStatus={brokerStatus} lossSummary={lossSummary} simMode={simMode} />

--- a/tcode/alpha_control_center/tests/ux_pending_cap.spec.ts
+++ b/tcode/alpha_control_center/tests/ux_pending_cap.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * UX Test: Pending Order Cap — Phase 8
+ *
+ * Verifies the pending-order cap UI features:
+ *  - Pending panel header shows "N/max" badge with correct colour at cap
+ *  - Each active order row shows a rank badge when rank > 0
+ *  - Replacement toast appears when a [REPLACE] cap event arrives
+ *  - Cap event feed renders REPLACE / REJECT-CAP entries
+ *
+ * Tests use route interception so no live IBKR gateway is required.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:2112';
+
+/** Minimal pending-orders response with a full queue (cap=2, 2 active). */
+function makePendingFull() {
+    return {
+        active: [
+            {
+                orderId: 1001,
+                status: 'Submitted',
+                symbol: 'TSLA',
+                action: 'BUY',
+                qty: 5,
+                strike: 365,
+                expiry: '2026-05-16',
+                option_type: 'CALL',
+                limit_price: 0.28,
+                filled_qty: 0,
+                avg_fill_price: 0,
+                timestamp: new Date().toISOString(),
+                rank: 0.55,
+            },
+            {
+                orderId: 1002,
+                status: 'PreSubmitted',
+                symbol: 'TSLA',
+                action: 'BUY',
+                qty: 3,
+                strike: 370,
+                expiry: '2026-05-16',
+                option_type: 'CALL',
+                limit_price: 0.18,
+                filled_qty: 0,
+                avg_fill_price: 0,
+                timestamp: new Date().toISOString(),
+                rank: 0.72,
+            },
+        ],
+        cancelled: [],
+        source: 'IBKR_PAPER',
+        cap: 2,
+    };
+}
+
+/** Cap events response with a REPLACE event. */
+function makeCapEvents(kind: 'REPLACE' | 'REJECT-CAP' = 'REPLACE') {
+    return {
+        events: [
+            {
+                ts: new Date().toISOString(),
+                kind,
+                cancelled_id: kind === 'REPLACE' ? 1001 : 0,
+                cancelled_rank: 0.55,
+                incoming_rank: 0.82,
+            },
+        ],
+        ranks: [{ order_id: 1002, rank: 0.72, placed_at: new Date().toISOString() }],
+        cap: 2,
+        pending_cnt: 1,
+    };
+}
+
+test.describe('Pending Cap UI', () => {
+    test('header badge shows N/cap and is red when at cap', async ({ page }) => {
+        // Intercept API responses
+        await page.route('**/api/orders/pending', (route) =>
+            route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(makePendingFull()) })
+        );
+        await page.route('**/api/orders/cap-events', (route) =>
+            route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(makeCapEvents()) })
+        );
+
+        await page.goto(BASE_URL, { waitUntil: 'load' });
+
+        // Find the pending-orders region
+        const panel = page.locator('[role="region"][aria-label*="Pending Orders"]');
+        await panel.waitFor({ state: 'visible', timeout: 15_000 });
+
+        // Badge should say "2/2"
+        const badge = panel.locator('.inline-badge').first();
+        await expect(badge).toContainText('2/2');
+
+        // At cap, text colour should be close to red (#f85149).
+        // We check via aria-label which includes the counts.
+        const badgeLabel = await badge.getAttribute('aria-label');
+        expect(badgeLabel).toMatch(/2 of 2 pending/i);
+    });
+
+    test('each active order row shows a rank badge', async ({ page }) => {
+        await page.route('**/api/orders/pending', (route) =>
+            route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(makePendingFull()) })
+        );
+        await page.route('**/api/orders/cap-events', (route) =>
+            route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(makeCapEvents()) })
+        );
+
+        await page.goto(BASE_URL, { waitUntil: 'load' });
+
+        const panel = page.locator('[role="region"][aria-label*="Pending Orders"]');
+        await panel.waitFor({ state: 'visible', timeout: 15_000 });
+
+        // Both rows should have a rank badge
+        const rankBadges = panel.locator('.inline-badge[title*="rank"]');
+        await expect(rankBadges).toHaveCount(2, { timeout: 8_000 });
+
+        const firstBadge = rankBadges.first();
+        const text = await firstBadge.textContent();
+        expect(text).toMatch(/rank: 0\.\d{2}/);
+    });
+
+    test('replacement toast appears on new REPLACE cap event', async ({ page }) => {
+        // First response: no events
+        let callCount = 0;
+        await page.route('**/api/orders/pending', (route) =>
+            route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(makePendingFull()) })
+        );
+        await page.route('**/api/orders/cap-events', (route) => {
+            callCount++;
+            const body = callCount === 1
+                ? JSON.stringify({ events: [], ranks: [], cap: 2, pending_cnt: 2 })
+                : JSON.stringify(makeCapEvents('REPLACE'));
+            route.fulfill({ status: 200, contentType: 'application/json', body });
+        });
+
+        await page.goto(BASE_URL, { waitUntil: 'load' });
+
+        // Wait for toast to appear (second poll delivers the REPLACE event)
+        const toast = page.locator('[data-testid="cap-replacement-toast"]');
+        await expect(toast).toBeVisible({ timeout: 25_000 });
+        const toastText = await toast.textContent();
+        expect(toastText).toMatch(/replaced orderId=1001/i);
+    });
+
+    test('cap event feed shows REPLACE entry when events exist', async ({ page }) => {
+        await page.route('**/api/orders/pending', (route) =>
+            route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(makePendingFull()) })
+        );
+        await page.route('**/api/orders/cap-events', (route) =>
+            route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(makeCapEvents('REPLACE')) })
+        );
+
+        await page.goto(BASE_URL, { waitUntil: 'load' });
+
+        const panel = page.locator('[role="region"][aria-label*="Pending Orders"]');
+        await panel.waitFor({ state: 'visible', timeout: 15_000 });
+
+        // Expand the cap events accordion
+        const capAccordion = panel.locator('[aria-label*="Cap events"]');
+        await capAccordion.waitFor({ state: 'visible', timeout: 10_000 });
+        await capAccordion.click();
+
+        // Check that a REPLACE entry is visible
+        const replaceEntry = panel.locator('text=[REPLACE]');
+        await expect(replaceEntry).toBeVisible({ timeout: 5_000 });
+    });
+});

--- a/tcode/alpha_control_center/tests/ux_pending_cap.spec.ts
+++ b/tcode/alpha_control_center/tests/ux_pending_cap.spec.ts
@@ -10,7 +10,7 @@
  * Tests use route interception so no live IBKR gateway is required.
  */
 
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 
 const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:2112';
 
@@ -56,7 +56,7 @@ function makePendingFull() {
 }
 
 /** Cap events response with a REPLACE event. */
-function makeCapEvents(kind: 'REPLACE' | 'REJECT-CAP' = 'REPLACE') {
+function makeCapEventsResponse(kind: 'REPLACE' | 'REJECT-CAP' = 'REPLACE') {
     return {
         events: [
             {
@@ -73,96 +73,99 @@ function makeCapEvents(kind: 'REPLACE' | 'REJECT-CAP' = 'REPLACE') {
     };
 }
 
+/** Register all intercepts before navigating. */
+async function setupRoutes(page: Page, capEventsBody: object) {
+    await page.route('**/api/orders/pending', (route) =>
+        route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(makePendingFull()),
+        })
+    );
+    await page.route('**/api/orders/cap-events', (route) =>
+        route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify(capEventsBody),
+        })
+    );
+}
+
+async function loadAndWaitForPanel(page: Page) {
+    await page.goto(BASE_URL, { waitUntil: 'load' });
+    const panel = page.locator('[role="region"][aria-label*="Pending Orders"]');
+    await panel.waitFor({ state: 'visible', timeout: 20_000 });
+    return panel;
+}
+
 test.describe('Pending Cap UI', () => {
     test('header badge shows N/cap and is red when at cap', async ({ page }) => {
-        // Intercept API responses
-        await page.route('**/api/orders/pending', (route) =>
-            route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(makePendingFull()) })
-        );
-        await page.route('**/api/orders/cap-events', (route) =>
-            route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(makeCapEvents()) })
-        );
+        await setupRoutes(page, makeCapEventsResponse());
+        const panel = await loadAndWaitForPanel(page);
 
-        await page.goto(BASE_URL, { waitUntil: 'load' });
+        // Badge should say "2/2" — wait up to 20s for the route intercept response to
+        // render (fetchPendingOrders fires 2s after mount)
+        const capBadge = panel.locator('.inline-badge[aria-label*="of"]');
+        await expect(capBadge).toBeVisible({ timeout: 20_000 });
+        await expect(capBadge).toContainText('2/2');
 
-        // Find the pending-orders region
-        const panel = page.locator('[role="region"][aria-label*="Pending Orders"]');
-        await panel.waitFor({ state: 'visible', timeout: 15_000 });
-
-        // Badge should say "2/2"
-        const badge = panel.locator('.inline-badge').first();
-        await expect(badge).toContainText('2/2');
-
-        // At cap, text colour should be close to red (#f85149).
-        // We check via aria-label which includes the counts.
-        const badgeLabel = await badge.getAttribute('aria-label');
-        expect(badgeLabel).toMatch(/2 of 2 pending/i);
+        // Confirm the aria-label contains both counts
+        const label = await capBadge.getAttribute('aria-label');
+        expect(label).toMatch(/2 of 2/i);
     });
 
     test('each active order row shows a rank badge', async ({ page }) => {
-        await page.route('**/api/orders/pending', (route) =>
-            route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(makePendingFull()) })
-        );
-        await page.route('**/api/orders/cap-events', (route) =>
-            route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(makeCapEvents()) })
-        );
+        await setupRoutes(page, makeCapEventsResponse());
+        const panel = await loadAndWaitForPanel(page);
 
-        await page.goto(BASE_URL, { waitUntil: 'load' });
-
-        const panel = page.locator('[role="region"][aria-label*="Pending Orders"]');
-        await panel.waitFor({ state: 'visible', timeout: 15_000 });
-
-        // Both rows should have a rank badge
+        // Wait for rank badges to appear (up to 20s for intercept to kick in)
         const rankBadges = panel.locator('.inline-badge[title*="rank"]');
-        await expect(rankBadges).toHaveCount(2, { timeout: 8_000 });
+        await expect(rankBadges).toHaveCount(2, { timeout: 20_000 });
 
-        const firstBadge = rankBadges.first();
-        const text = await firstBadge.textContent();
-        expect(text).toMatch(/rank: 0\.\d{2}/);
+        const firstText = await rankBadges.first().textContent();
+        expect(firstText).toMatch(/rank: 0\.\d{2}/);
     });
 
     test('replacement toast appears on new REPLACE cap event', async ({ page }) => {
-        // First response: no events
+        // First response: no events; second response: REPLACE event
         let callCount = 0;
         await page.route('**/api/orders/pending', (route) =>
-            route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(makePendingFull()) })
+            route.fulfill({
+                status: 200,
+                contentType: 'application/json',
+                body: JSON.stringify(makePendingFull()),
+            })
         );
         await page.route('**/api/orders/cap-events', (route) => {
             callCount++;
             const body = callCount === 1
                 ? JSON.stringify({ events: [], ranks: [], cap: 2, pending_cnt: 2 })
-                : JSON.stringify(makeCapEvents('REPLACE'));
+                : JSON.stringify(makeCapEventsResponse('REPLACE'));
             route.fulfill({ status: 200, contentType: 'application/json', body });
         });
 
         await page.goto(BASE_URL, { waitUntil: 'load' });
 
-        // Wait for toast to appear (second poll delivers the REPLACE event)
+        // Wait for toast to appear — second poll at 15s interval fires the REPLACE event
+        // Total wait budget: 30s (initial 2.5s + 15s interval + rendering buffer)
         const toast = page.locator('[data-testid="cap-replacement-toast"]');
-        await expect(toast).toBeVisible({ timeout: 25_000 });
+        await expect(toast).toBeVisible({ timeout: 30_000 });
         const toastText = await toast.textContent();
         expect(toastText).toMatch(/replaced orderId=1001/i);
     });
 
-    test('cap event feed shows REPLACE entry when events exist', async ({ page }) => {
-        await page.route('**/api/orders/pending', (route) =>
-            route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(makePendingFull()) })
-        );
-        await page.route('**/api/orders/cap-events', (route) =>
-            route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(makeCapEvents('REPLACE')) })
-        );
+    test('cap event feed accordion shows REPLACE entry when events exist', async ({ page }) => {
+        await setupRoutes(page, makeCapEventsResponse('REPLACE'));
+        const panel = await loadAndWaitForPanel(page);
 
-        await page.goto(BASE_URL, { waitUntil: 'load' });
-
-        const panel = page.locator('[role="region"][aria-label*="Pending Orders"]');
-        await panel.waitFor({ state: 'visible', timeout: 15_000 });
-
-        // Expand the cap events accordion
+        // Wait for the cap events accordion to appear (fetchCapEvents fires 2.5s after mount)
+        // aria-label: "Cap events — 1 recent. Click to expand."
         const capAccordion = panel.locator('[aria-label*="Cap events"]');
-        await capAccordion.waitFor({ state: 'visible', timeout: 10_000 });
-        await capAccordion.click();
+        await expect(capAccordion).toBeVisible({ timeout: 20_000 });
+        // Force-click to avoid overlay interception in the scrollable column
+        await capAccordion.click({ force: true });
 
-        // Check that a REPLACE entry is visible
+        // REPLACE entry should be visible in the expanded feed
         const replaceEntry = panel.locator('text=[REPLACE]');
         await expect(replaceEntry).toBeVisible({ timeout: 5_000 });
     });

--- a/tcode/alpha_engine/ingestion/ibkr_account.py
+++ b/tcode/alpha_engine/ingestion/ibkr_account.py
@@ -2,11 +2,16 @@
 TSLA Alpha Engine: IBKR Account + Positions Fetcher
 Retrieves live account summary, positions, fills, and P&L from IB Gateway.
 
-CLI modes (for Go subprocess calls):
+CLI sub-commands (for Go subprocess calls):
   python -m ingestion.ibkr_account account
   python -m ingestion.ibkr_account positions
   python -m ingestion.ibkr_account fills [hours]
   python -m ingestion.ibkr_account pnl
+
+Mode aliases (Phase 4+ vocabulary) -- also accepted as argv[1]:
+  python -m ingestion.ibkr_account IBKR_PAPER   -> alias for "account"
+  python -m ingestion.ibkr_account IBKR_LIVE    -> alias for "account"
+  python -m ingestion.ibkr_account SIMULATION   -> returns error (no broker)
 """
 import json
 import logging
@@ -20,6 +25,36 @@ from datetime import datetime, timezone
 logger = logging.getLogger("IBKRAccount")
 
 DB_PATH = os.path.expanduser("~/tsla_alpha.db")
+
+
+# ── mode normalizer ────────────────────────────────────────────────────────────
+
+_MODE_ALIASES = {
+    "IBKR_PAPER": "PAPER",
+    "PAPER":      "PAPER",
+    "IBKR_LIVE":  "LIVE",
+    "LIVE":       "LIVE",
+    "SIMULATION": "SIMULATION",
+    "SIM":        "SIMULATION",
+}
+
+_SUBCOMMANDS = {"account", "positions", "fills", "pnl"}
+
+
+def normalize_mode(m: str) -> str:
+    """
+    Translate execution mode vocabulary to a canonical string.
+
+    Accepts Phase 4+ strings (IBKR_PAPER, IBKR_LIVE, SIMULATION) and legacy
+    short forms (paper, live, sim) in any case.
+
+    Returns one of: "PAPER", "LIVE", "SIMULATION".
+    Raises ValueError for unrecognised strings.
+    """
+    key = m.strip().upper()
+    if key in _MODE_ALIASES:
+        return _MODE_ALIASES[key]
+    raise ValueError(f"Unknown mode: {m!r}")
 
 
 def _nan_to_zero(v) -> float:
@@ -205,7 +240,7 @@ def get_pnl() -> dict:
 # ── helpers ───────────────────────────────────────────────────────────────────
 
 def _fmt_expiry(raw: str) -> str:
-    """Convert YYYYMMDD → YYYY-MM-DD."""
+    """Convert YYYYMMDD -> YYYY-MM-DD."""
     raw = (raw or "").strip()
     if len(raw) == 8 and raw.isdigit():
         return f"{raw[:4]}-{raw[4:6]}-{raw[6:]}"
@@ -237,20 +272,39 @@ def _lookup_signal(ticker: str, strike: int, expiration: str, option_type: str):
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.WARNING)
-    mode = sys.argv[1] if len(sys.argv) > 1 else "account"
+    arg1 = sys.argv[1] if len(sys.argv) > 1 else "account"
+
+    # Accept execution mode vocabulary (IBKR_PAPER, IBKR_LIVE, SIMULATION, ...)
+    # as an alias for the "account" sub-command so callers using either
+    # Phase 4+ or legacy vocabulary work without modification.
+    if arg1 not in _SUBCOMMANDS:
+        try:
+            canonical = normalize_mode(arg1)
+        except ValueError:
+            print(json.dumps({"error": f"Unknown mode: {arg1}"}))
+            sys.exit(1)
+        if canonical == "SIMULATION":
+            print(json.dumps({
+                "error": "SIMULATION mode -- no broker connected",
+                "ibkr_connected": False,
+                "source": "SIMULATION",
+            }))
+            sys.exit(0)
+        # PAPER or LIVE -> run the "account" sub-command; port is set by env vars.
+        arg1 = "account"
 
     try:
-        if mode == "account":
+        if arg1 == "account":
             print(json.dumps(get_account_summary()))
-        elif mode == "positions":
+        elif arg1 == "positions":
             print(json.dumps(get_positions()))
-        elif mode == "fills":
+        elif arg1 == "fills":
             hours = int(sys.argv[2]) if len(sys.argv) > 2 else 24
             print(json.dumps(get_fills(hours)))
-        elif mode == "pnl":
+        elif arg1 == "pnl":
             print(json.dumps(get_pnl()))
         else:
-            print(json.dumps({"error": f"Unknown mode: {mode}"}))
+            print(json.dumps({"error": f"Unknown sub-command: {arg1}"}))
     except ConnectionError as e:
         print(json.dumps({"error": str(e), "ibkr_connected": False}))
     except Exception as e:

--- a/tcode/alpha_engine/ingestion/ibkr_order.py
+++ b/tcode/alpha_engine/ingestion/ibkr_order.py
@@ -308,12 +308,21 @@ def main() -> None:
     parser.add_argument("--client-id",   type=int, default=3, dest="client_id")
     args = parser.parse_args()
 
-    # Safety gate: refuse to execute unless mode is an IBKR paper mode.
-    if args.mode not in ("IBKR_PAPER", "IBKR_LIVE"):
+    # Normalise mode vocabulary: accept both legacy ("paper"/"live") and
+    # Phase 4+ ("IBKR_PAPER"/"IBKR_LIVE") strings before the safety gate.
+    _mode_norm = {
+        "IBKR_PAPER": "IBKR_PAPER",
+        "PAPER":      "IBKR_PAPER",
+        "IBKR_LIVE":  "IBKR_LIVE",
+        "LIVE":       "IBKR_LIVE",
+    }
+    normalised_mode = _mode_norm.get(args.mode.strip().upper(), "")
+    if not normalised_mode:
         print(json.dumps({
             "error": f"Refusing order: mode={args.mode!r} is not a real IBKR mode"
         }))
         sys.exit(1)
+    args.mode = normalised_mode
 
     if args.mode == "IBKR_LIVE":
         msg = "IBKR_LIVE mode is experimental and not enabled in this build"

--- a/tcode/alpha_engine/tests/test_ibkr_mode_normalizer.py
+++ b/tcode/alpha_engine/tests/test_ibkr_mode_normalizer.py
@@ -1,0 +1,78 @@
+"""
+Phase 8 — Bug 1 fix: ibkr_account.py mode vocabulary normalizer tests.
+
+Verifies that normalize_mode() accepts both Phase 4+ (IBKR_PAPER / IBKR_LIVE /
+SIMULATION) and legacy (paper / live / sim) strings, and that the CLI entry
+point handles mode-string argv[1] correctly without shelling out to the broker.
+"""
+import importlib
+import sys
+import types
+import pytest
+
+
+def _import_ibkr_account():
+    """Import ibkr_account module without triggering IB Gateway connection."""
+    spec = importlib.util.spec_from_file_location(
+        "ibkr_account",
+        "/home/builder/src/gpfiles/tcode/alpha_engine/ingestion/ibkr_account.py",
+    )
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    # Stub out the ingestion sub-package so ib_insync imports are skipped.
+    sys.modules.setdefault("ingestion", types.ModuleType("ingestion"))
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+@pytest.fixture(scope="module")
+def ibkr_account():
+    return _import_ibkr_account()
+
+
+class TestNormalizeMode:
+    def test_ibkr_paper_normalises_to_paper(self, ibkr_account):
+        assert ibkr_account.normalize_mode("IBKR_PAPER") == "PAPER"
+
+    def test_paper_normalises_to_paper(self, ibkr_account):
+        assert ibkr_account.normalize_mode("PAPER") == "PAPER"
+
+    def test_paper_lowercase(self, ibkr_account):
+        assert ibkr_account.normalize_mode("paper") == "PAPER"
+
+    def test_ibkr_live_normalises_to_live(self, ibkr_account):
+        assert ibkr_account.normalize_mode("IBKR_LIVE") == "LIVE"
+
+    def test_live_normalises_to_live(self, ibkr_account):
+        assert ibkr_account.normalize_mode("LIVE") == "LIVE"
+
+    def test_simulation_normalises_to_simulation(self, ibkr_account):
+        assert ibkr_account.normalize_mode("SIMULATION") == "SIMULATION"
+
+    def test_sim_normalises_to_simulation(self, ibkr_account):
+        assert ibkr_account.normalize_mode("SIM") == "SIMULATION"
+
+    def test_unknown_raises_value_error(self, ibkr_account):
+        with pytest.raises(ValueError, match="Unknown mode"):
+            ibkr_account.normalize_mode("FOOBAR")
+
+    def test_whitespace_trimmed(self, ibkr_account):
+        assert ibkr_account.normalize_mode("  IBKR_PAPER  ") == "PAPER"
+
+
+class TestSubcommandsSet:
+    """Ensure _SUBCOMMANDS contains expected values and excludes mode strings."""
+
+    def test_account_in_subcommands(self, ibkr_account):
+        assert "account" in ibkr_account._SUBCOMMANDS
+
+    def test_positions_in_subcommands(self, ibkr_account):
+        assert "positions" in ibkr_account._SUBCOMMANDS
+
+    def test_fills_in_subcommands(self, ibkr_account):
+        assert "fills" in ibkr_account._SUBCOMMANDS
+
+    def test_pnl_in_subcommands(self, ibkr_account):
+        assert "pnl" in ibkr_account._SUBCOMMANDS
+
+    def test_ibkr_paper_not_in_subcommands(self, ibkr_account):
+        assert "IBKR_PAPER" not in ibkr_account._SUBCOMMANDS

--- a/tcode/execution_engine/api.go
+++ b/tcode/execution_engine/api.go
@@ -1700,12 +1700,25 @@ func (h *ConfigHandler) ServeOrdersPending(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	active    := []OrderResult{}
+	active    := []interface{}{}
 	cancelled := []OrderResult{}
+	maxPending := envIntOrDefault("MAX_PENDING_ORDERS", 2)
+	capOrders  := GetPendingCapOrders()
+	rankByID   := make(map[int]float64, len(capOrders))
+	for _, info := range capOrders {
+		rankByID[info.OrderID] = info.Rank
+	}
+
 	for _, o := range orders {
 		switch {
 		case pendingActiveStatuses[o.Status]:
-			active = append(active, o)
+			// Merge stored rank into the order DTO.
+			type pendingDTO struct {
+				OrderResult
+				Rank float64 `json:"rank"`
+			}
+			rank := rankByID[o.OrderID] // 0.0 if not tracked
+			active = append(active, pendingDTO{OrderResult: o, Rank: rank})
 		case o.Status == "Cancelled":
 			cancelled = append(cancelled, o)
 		}
@@ -1715,6 +1728,57 @@ func (h *ConfigHandler) ServeOrdersPending(w http.ResponseWriter, r *http.Reques
 		"active":    active,
 		"cancelled": cancelled,
 		"source":    string(ActiveExecutionMode),
+		"cap":       maxPending,
+	})
+}
+
+// ServeCapEvents returns the last 10 [REPLACE] / [REJECT-CAP] events for the UI feed.
+func (h *ConfigHandler) ServeCapEvents(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	events := GetCapEvents()
+	maxPending := envIntOrDefault("MAX_PENDING_ORDERS", 2)
+
+	type eventDTO struct {
+		Ts            string  `json:"ts"`
+		Kind          string  `json:"kind"`
+		CancelledID   int     `json:"cancelled_id,omitempty"`
+		CancelledRank float64 `json:"cancelled_rank"`
+		IncomingRank  float64 `json:"incoming_rank"`
+	}
+	dtos := make([]eventDTO, 0, len(events))
+	for _, ev := range events {
+		dtos = append(dtos, eventDTO{
+			Ts:            ev.Ts.Format(time.RFC3339),
+			Kind:          ev.Kind,
+			CancelledID:   ev.CancelledID,
+			CancelledRank: ev.CancelledRank,
+			IncomingRank:  ev.IncomingRank,
+		})
+	}
+
+	// Also include current pending rank snapshot.
+	capOrders := GetPendingCapOrders()
+	type rankDTO struct {
+		OrderID  int     `json:"order_id"`
+		Rank     float64 `json:"rank"`
+		PlacedAt string  `json:"placed_at"`
+	}
+	ranks := make([]rankDTO, 0, len(capOrders))
+	for _, o := range capOrders {
+		ranks = append(ranks, rankDTO{
+			OrderID:  o.OrderID,
+			Rank:     o.Rank,
+			PlacedAt: o.PlacedAt.Format(time.RFC3339),
+		})
+	}
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"events":      dtos,
+		"ranks":       ranks,
+		"cap":         maxPending,
+		"pending_cnt": activePendingCount(),
 	})
 }
 

--- a/tcode/execution_engine/main.go
+++ b/tcode/execution_engine/main.go
@@ -222,6 +222,7 @@ func main() {
 	mux.HandleFunc("/api/losses", configHandler.ServeLossSummary)
 	mux.HandleFunc("/api/fills/tag", configHandler.ServeTagTrade)
 	mux.HandleFunc("/api/orders/pending", configHandler.ServeOrdersPending)
+	mux.HandleFunc("/api/orders/cap-events", configHandler.ServeCapEvents)
 
 	// Live Reload WebSocket (Task: Auto-Refresh)
 	mux.Handle("/dev/ws", GlobalReloader)

--- a/tcode/execution_engine/order_dedup_test.go
+++ b/tcode/execution_engine/order_dedup_test.go
@@ -104,3 +104,51 @@ func TestSignalFingerprintFormat(t *testing.T) {
 		t.Errorf("fingerprint = %q, want %q", fp, expected)
 	}
 }
+
+// TestCheckAndMarkOrderConcurrent verifies that the package-level dedup map
+// (Bug 2 fix) has no data races under concurrent access.
+// Run with: go test -race ./...
+func TestCheckAndMarkOrderConcurrent(t *testing.T) {
+	// Reset the global dedup map for this test.
+	orderDedupMu.Lock()
+	orderDedup = map[string]orderState{}
+	orderDedupMu.Unlock()
+
+	fp := signalFingerprint("TSLA", "CALL", "2026-05-16", "BUY", 370.0, 5)
+	fakeResult := orderState{OrderID: 99, Status: "PreSubmitted"}
+
+	var wg sync.WaitGroup
+	placedCount := 0
+	var placedMu sync.Mutex
+
+	// 20 goroutines all racing to check-and-mark the same fingerprint.
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			shouldPlace, _ := checkAndMarkOrder(fp, orderState{OrderID: 0, Status: "pending"})
+			if shouldPlace {
+				// Simulate broker returning a real order ID.
+				updateOrderState(fp, fakeResult)
+				placedMu.Lock()
+				placedCount++
+				placedMu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Only one goroutine should have won the race to place.
+	if placedCount != 1 {
+		t.Errorf("expected exactly 1 placement from 20 concurrent goroutines, got %d", placedCount)
+	}
+
+	// Final state should reflect the placed order.
+	state, ok := readOrderState(fp)
+	if !ok {
+		t.Fatal("expected dedup entry to exist after placement")
+	}
+	if state.Status != "PreSubmitted" {
+		t.Errorf("expected status PreSubmitted, got %q", state.Status)
+	}
+}

--- a/tcode/execution_engine/rank_cap_test.go
+++ b/tcode/execution_engine/rank_cap_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// ── computeRank tests ─────────────────────────────────────────────────────────
+
+func TestRankHighConfidenceHighROI(t *testing.T) {
+	sig := AlphaSignal{
+		Confidence:       0.95,
+		Timestamp:        float64(time.Now().Unix()), // fresh
+		TargetLimitPrice: 1.0,
+		TakeProfitPrice:  2.0, // 100% ROI
+	}
+	rank := computeRank(sig)
+	if rank < 0.7 {
+		t.Errorf("high confidence + high ROI fresh signal should rank > 0.7, got %.3f", rank)
+	}
+	if rank > 1.0 {
+		t.Errorf("rank must be capped at 1.0, got %.3f", rank)
+	}
+}
+
+func TestRankLowConfidenceLowROI(t *testing.T) {
+	sig := AlphaSignal{
+		Confidence:       0.2,
+		Timestamp:        float64(time.Now().Unix()),
+		TargetLimitPrice: 1.0,
+		TakeProfitPrice:  1.05, // 5% ROI
+	}
+	rank := computeRank(sig)
+	if rank > 0.4 {
+		t.Errorf("low confidence + low ROI signal should rank < 0.4, got %.3f", rank)
+	}
+}
+
+func TestRankStaleSignalPenalised(t *testing.T) {
+	fresh := AlphaSignal{
+		Confidence:       0.8,
+		Timestamp:        float64(time.Now().Unix()),
+		TargetLimitPrice: 1.0,
+		TakeProfitPrice:  1.5,
+	}
+	// 45-minute-old signal
+	stale := AlphaSignal{
+		Confidence:       0.8,
+		Timestamp:        float64(time.Now().Add(-45 * time.Minute).Unix()),
+		TargetLimitPrice: 1.0,
+		TakeProfitPrice:  1.5,
+	}
+	freshRank := computeRank(fresh)
+	staleRank := computeRank(stale)
+	if staleRank >= freshRank {
+		t.Errorf("stale signal (%.3f) should rank lower than fresh (%.3f)", staleRank, freshRank)
+	}
+}
+
+func TestRankClampedToUnitInterval(t *testing.T) {
+	// Zero fields — should not panic or return outside [0,1].
+	sig := AlphaSignal{Confidence: 0}
+	rank := computeRank(sig)
+	if rank < 0 || rank > 1 {
+		t.Errorf("rank must be in [0,1], got %.3f", rank)
+	}
+
+	// Confidence > 1 (shouldn't happen, but guard against it).
+	sig2 := AlphaSignal{Confidence: 5.0, Timestamp: float64(time.Now().Unix())}
+	rank2 := computeRank(sig2)
+	if rank2 > 1 {
+		t.Errorf("rank must be capped at 1.0 even with over-range confidence, got %.3f", rank2)
+	}
+}
+
+func TestRankROICapAt100Pct(t *testing.T) {
+	// ROI 1000% should not inflate rank above what ROI=100% gives.
+	base := AlphaSignal{
+		Confidence:       0.5,
+		Timestamp:        float64(time.Now().Unix()),
+		TargetLimitPrice: 1.0,
+		TakeProfitPrice:  2.0, // 100% ROI — hits cap
+	}
+	extreme := AlphaSignal{
+		Confidence:       0.5,
+		Timestamp:        float64(time.Now().Unix()),
+		TargetLimitPrice: 1.0,
+		TakeProfitPrice:  100.0, // 9900% ROI — beyond cap
+	}
+	diff := math.Abs(computeRank(base) - computeRank(extreme))
+	if diff > 0.001 {
+		t.Errorf("ROI beyond 100%% should be capped; base=%.3f extreme=%.3f diff=%.4f",
+			computeRank(base), computeRank(extreme), diff)
+	}
+}
+
+// ── Pending cap helper tests ──────────────────────────────────────────────────
+
+func resetPendingCapState() {
+	pendingCapMu.Lock()
+	pendingCapOrders = map[int]pendingOrderInfo{}
+	pendingCapMu.Unlock()
+	capEventsMu.Lock()
+	capEvents = nil
+	capEventsMu.Unlock()
+}
+
+func TestActivePendingCountEmpty(t *testing.T) {
+	resetPendingCapState()
+	if n := activePendingCount(); n != 0 {
+		t.Errorf("expected 0 pending, got %d", n)
+	}
+}
+
+func TestAddAndRemovePendingOrder(t *testing.T) {
+	resetPendingCapState()
+	sig := AlphaSignal{Confidence: 0.8}
+	addPendingOrder(101, 0.75, sig)
+	addPendingOrder(102, 0.60, sig)
+	if n := activePendingCount(); n != 2 {
+		t.Fatalf("expected 2 pending, got %d", n)
+	}
+	removePendingOrder(101)
+	if n := activePendingCount(); n != 1 {
+		t.Errorf("expected 1 pending after remove, got %d", n)
+	}
+}
+
+func TestLowestRankedPending(t *testing.T) {
+	resetPendingCapState()
+	sig := AlphaSignal{Confidence: 0.5}
+	addPendingOrder(10, 0.90, sig)
+	addPendingOrder(11, 0.45, sig)
+	addPendingOrder(12, 0.72, sig)
+
+	lowest, found := lowestRankedPending()
+	if !found {
+		t.Fatal("expected to find lowest ranked pending order")
+	}
+	if lowest.OrderID != 11 {
+		t.Errorf("expected orderId=11 (rank 0.45), got orderId=%d rank=%.3f", lowest.OrderID, lowest.Rank)
+	}
+}
+
+func TestCapEventRecording(t *testing.T) {
+	capEventsMu.Lock()
+	capEvents = nil
+	capEventsMu.Unlock()
+
+	recordCapEvent(capReplacementEvent{Ts: time.Now(), Kind: "REPLACE", CancelledID: 5, CancelledRank: 0.4, IncomingRank: 0.8})
+	recordCapEvent(capReplacementEvent{Ts: time.Now(), Kind: "REJECT-CAP", IncomingRank: 0.3, CancelledRank: 0.5})
+
+	evs := GetCapEvents()
+	if len(evs) != 2 {
+		t.Fatalf("expected 2 cap events, got %d", len(evs))
+	}
+	// Most recent event should be first.
+	if evs[0].Kind != "REJECT-CAP" {
+		t.Errorf("expected most recent event first (REJECT-CAP), got %s", evs[0].Kind)
+	}
+}
+
+func TestCapEventRingBuffer(t *testing.T) {
+	capEventsMu.Lock()
+	capEvents = nil
+	capEventsMu.Unlock()
+
+	// Add 15 events — ring buffer should cap at 10.
+	for i := 0; i < 15; i++ {
+		recordCapEvent(capReplacementEvent{Ts: time.Now(), Kind: "REPLACE"})
+	}
+	evs := GetCapEvents()
+	if len(evs) != 10 {
+		t.Errorf("expected ring buffer to hold exactly 10 events, got %d", len(evs))
+	}
+}

--- a/tcode/execution_engine/subscriber.go
+++ b/tcode/execution_engine/subscriber.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math"
 	"sync"
 	"time"
 
@@ -41,6 +42,9 @@ type AlphaSignal struct {
 	IBKROrderID int    `json:"ibkr_order_id,omitempty"` // > 0 when order reached broker
 	ExecStatus  string `json:"exec_status,omitempty"`   // "submitted" | "failed" | "sim_filled" | "rejected"
 	ExecError   string `json:"exec_error,omitempty"`    // non-empty on failure
+
+	// Rank assigned at placement time (for pending-cap comparisons in UI).
+	SignalRank float64 `json:"signal_rank,omitempty"`
 }
 
 // orderState tracks the last-known status for a signal fingerprint so we can
@@ -48,6 +52,24 @@ type AlphaSignal struct {
 type orderState struct {
 	OrderID int
 	Status  string
+}
+
+// pendingOrderInfo stores rank and originating signal data alongside an IBKR
+// pending order.  Kept in-memory; TODO(phase-9): persist to SQLite for restart durability.
+type pendingOrderInfo struct {
+	OrderID  int
+	Rank     float64
+	Signal   AlphaSignal
+	PlacedAt time.Time
+}
+
+// capReplacementEvent is a ring-buffer entry for the UI event feed.
+type capReplacementEvent struct {
+	Ts            time.Time
+	Kind          string // "REPLACE" or "REJECT-CAP"
+	CancelledID   int
+	CancelledRank float64
+	IncomingRank  float64
 }
 
 // activeStatuses is the set of IBKR statuses that mean an order is already
@@ -60,6 +82,165 @@ var activeStatuses = map[string]bool{
 	"Filled":        true,
 }
 
+// ── Bug 2 fix: package-level dedup map protected by sync.RWMutex ─────────────
+// Lifted out of SignalSubscriber so the mutex is explicit and any future helper
+// (e.g. the cap-check path) cannot race against the NATS handler goroutine.
+
+var (
+	orderDedupMu sync.RWMutex
+	orderDedup   = map[string]orderState{}
+)
+
+// inFlightStatuses extends activeStatuses with an internal sentinel used while
+// the order placement is in progress.  Any goroutine that sees "pending" should
+// also skip re-entry, ensuring exactly one goroutine places per fingerprint.
+var inFlightStatuses = map[string]bool{
+	"PreSubmitted":  true,
+	"Submitted":     true,
+	"PendingSubmit": true,
+	"Filled":        true,
+	"pending":       true, // in-flight sentinel; cleared on error
+}
+
+// checkAndMarkOrder atomically checks whether a fingerprint has an active or
+// in-flight order and, if not, reserves it with a "pending" sentinel.
+// Returns (shouldPlace bool, prevState orderState).
+// The entire check+mark is under the write lock so concurrent goroutines cannot
+// both return shouldPlace=true for the same fingerprint (Bug 2 fix).
+func checkAndMarkOrder(fp string, newState orderState) (shouldPlace bool, prev orderState) {
+	orderDedupMu.Lock()
+	defer orderDedupMu.Unlock()
+	prev = orderDedup[fp]
+	if prev.Status != "" && inFlightStatuses[prev.Status] {
+		return false, prev
+	}
+	orderDedup[fp] = newState
+	return true, prev
+}
+
+// updateOrderState records the latest known broker state for a fingerprint.
+func updateOrderState(fp string, state orderState) {
+	orderDedupMu.Lock()
+	defer orderDedupMu.Unlock()
+	orderDedup[fp] = state
+}
+
+// readOrderState returns the last-known state for a fingerprint (read-only).
+func readOrderState(fp string) (orderState, bool) {
+	orderDedupMu.RLock()
+	defer orderDedupMu.RUnlock()
+	s, ok := orderDedup[fp]
+	return s, ok
+}
+
+// ── Pending-order cap ─────────────────────────────────────────────────────────
+
+var (
+	pendingCapMu     sync.RWMutex
+	pendingCapOrders = map[int]pendingOrderInfo{}
+)
+
+var (
+	capEventsMu sync.RWMutex
+	capEvents   []capReplacementEvent // last 10 events
+)
+
+func recordCapEvent(ev capReplacementEvent) {
+	capEventsMu.Lock()
+	defer capEventsMu.Unlock()
+	capEvents = append([]capReplacementEvent{ev}, capEvents...)
+	if len(capEvents) > 10 {
+		capEvents = capEvents[:10]
+	}
+}
+
+// GetCapEvents returns the last ≤10 cap replacement events for the UI feed.
+func GetCapEvents() []capReplacementEvent {
+	capEventsMu.RLock()
+	defer capEventsMu.RUnlock()
+	out := make([]capReplacementEvent, len(capEvents))
+	copy(out, capEvents)
+	return out
+}
+
+// computeRank scores a signal on [0,1] using confidence, return-on-cost, and recency.
+//
+//	rank = confidence * 0.5
+//	     + min((TakeProfit - LimitPrice) / LimitPrice, 1.0) * 0.3
+//	     + exp(-age_seconds / 600) * 0.2
+func computeRank(sig AlphaSignal) float64 {
+	// Confidence component
+	conf := math.Max(0, math.Min(1, sig.Confidence))
+
+	// Return-on-cost: (TP - LimitPrice) / LimitPrice, capped at 1.0
+	roi := 0.0
+	if sig.TargetLimitPrice > 0 && sig.TakeProfitPrice > sig.TargetLimitPrice {
+		roi = math.Min((sig.TakeProfitPrice-sig.TargetLimitPrice)/sig.TargetLimitPrice, 1.0)
+	}
+
+	// Recency: e^(-age/600) — fresh≈1, 10 min≈0.37, 30 min≈0.05
+	ageSec := time.Since(time.Unix(int64(sig.Timestamp), 0)).Seconds()
+	if ageSec < 0 {
+		ageSec = 0
+	}
+	recency := math.Exp(-ageSec / 600.0)
+
+	rank := conf*0.5 + roi*0.3 + recency*0.2
+	return math.Max(0, math.Min(1, rank))
+}
+
+// lowestRankedPending returns the pending order with the lowest rank.
+func lowestRankedPending() (lowest pendingOrderInfo, found bool) {
+	pendingCapMu.RLock()
+	defer pendingCapMu.RUnlock()
+	for _, info := range pendingCapOrders {
+		if !found || info.Rank < lowest.Rank {
+			lowest = info
+			found = true
+		}
+	}
+	return
+}
+
+// addPendingOrder records a newly placed order in the cap tracker.
+func addPendingOrder(orderID int, rank float64, sig AlphaSignal) {
+	pendingCapMu.Lock()
+	defer pendingCapMu.Unlock()
+	pendingCapOrders[orderID] = pendingOrderInfo{
+		OrderID:  orderID,
+		Rank:     rank,
+		Signal:   sig,
+		PlacedAt: time.Now(),
+	}
+}
+
+// removePendingOrder removes a cancelled or filled order from the cap tracker.
+func removePendingOrder(orderID int) {
+	pendingCapMu.Lock()
+	defer pendingCapMu.Unlock()
+	delete(pendingCapOrders, orderID)
+}
+
+// activePendingCount returns the number of orders tracked as pending.
+func activePendingCount() int {
+	pendingCapMu.RLock()
+	defer pendingCapMu.RUnlock()
+	return len(pendingCapOrders)
+}
+
+// GetPendingCapOrders returns a snapshot of tracked pending orders for the UI.
+func GetPendingCapOrders() []pendingOrderInfo {
+	pendingCapMu.RLock()
+	defer pendingCapMu.RUnlock()
+	out := make([]pendingOrderInfo, 0, len(pendingCapOrders))
+	for _, v := range pendingCapOrders {
+		out = append(out, v)
+	}
+	return out
+}
+
+// ── SignalSubscriber ──────────────────────────────────────────────────────────
+
 // SignalSubscriber listens for Alpha Engine broadcasts and triggers execution.
 type SignalSubscriber struct {
 	Conn       *nats.Conn
@@ -68,21 +249,15 @@ type SignalSubscriber struct {
 	Guard      *LiveCapitalGuard
 	Compliance *ComplianceGuard
 	Archive    *ArchiveSink
-
-	// orderFingerprints deduplicates signal → order calls.
-	// Key: "<strike>_<expiry>_<action>_<qty>"  Value: last-known orderState.
-	orderFingerprints   map[string]orderState
-	orderFingerprintsMu sync.Mutex
 }
 
 func NewSignalSubscriber(natsURL string, executor *IBKRExecutor, pricing *PricingEngine, guard *LiveCapitalGuard, compliance *ComplianceGuard, archive *ArchiveSink) *SignalSubscriber {
 	sub := &SignalSubscriber{
-		Executor:          executor,
-		Pricing:           pricing,
-		Guard:             guard,
-		Compliance:        compliance,
-		Archive:           archive,
-		orderFingerprints: make(map[string]orderState),
+		Executor:   executor,
+		Pricing:    pricing,
+		Guard:      guard,
+		Compliance: compliance,
+		Archive:    archive,
 	}
 	nc, err := nats.Connect(natsURL)
 	if err != nil {
@@ -207,10 +382,9 @@ func (s *SignalSubscriber) Start() {
 
 			// ── Dedup: skip if an order with the same fingerprint is already active ──
 			fp := signalFingerprint(ticker, sig.OptionType, sig.ExpirationDate, action, strike, absQty)
-			s.orderFingerprintsMu.Lock()
-			prev, exists := s.orderFingerprints[fp]
-			s.orderFingerprintsMu.Unlock()
-			if exists && activeStatuses[prev.Status] {
+			// checkAndMarkOrder is atomic (RWMutex-protected) — Bug 2 fix.
+			shouldPlace, prev := checkAndMarkOrder(fp, orderState{OrderID: 0, Status: "pending"})
+			if !shouldPlace {
 				log.Printf("[SKIP] duplicate signal — orderId=%d status=%s fingerprint=%s",
 					prev.OrderID, prev.Status, fp)
 				sig.IBKROrderID = prev.OrderID
@@ -219,29 +393,79 @@ func (s *SignalSubscriber) Start() {
 				break
 			}
 
+			// ── Pending-order cap: rank-based replacement ──────────────────────
+			incomingRank := computeRank(sig)
+			maxPending := envIntOrDefault("MAX_PENDING_ORDERS", 2)
+
+			if activePendingCount() >= maxPending {
+				lowest, found := lowestRankedPending()
+				if !found || incomingRank <= lowest.Rank {
+					log.Printf("[REJECT-CAP] pending queue full (%d/%d), incoming rank=%.3f <= lowest=%.3f",
+						activePendingCount(), maxPending, incomingRank, lowest.Rank)
+					sig.ExecStatus = "rejected"
+					sig.ExecError = fmt.Sprintf("pending_cap_full:rank=%.3f:cutoff=%.3f", incomingRank, lowest.Rank)
+					// Clear the tentative dedup entry so future higher-rank signals aren't blocked.
+					updateOrderState(fp, orderState{})
+					AddSignal(sig)
+					recordCapEvent(capReplacementEvent{
+						Ts:            time.Now(),
+						Kind:          "REJECT-CAP",
+						CancelledID:   0,
+						CancelledRank: lowest.Rank,
+						IncomingRank:  incomingRank,
+					})
+					break
+				}
+
+				// Incoming signal outranks the lowest pending — cancel it.
+				if err := CancelIBKROrder(lowest.OrderID); err != nil {
+					log.Printf("[CANCEL-FAIL] orderId=%d: %v", lowest.OrderID, err)
+					sig.ExecStatus = "rejected"
+					sig.ExecError = fmt.Sprintf("cancel_failed:orderId=%d", lowest.OrderID)
+					updateOrderState(fp, orderState{})
+					AddSignal(sig)
+					break
+				}
+				removePendingOrder(lowest.OrderID)
+				log.Printf("[REPLACE] cancelled orderId=%d (rank=%.3f) for better rank=%.3f",
+					lowest.OrderID, lowest.Rank, incomingRank)
+				recordCapEvent(capReplacementEvent{
+					Ts:            time.Now(),
+					Kind:          "REPLACE",
+					CancelledID:   lowest.OrderID,
+					CancelledRank: lowest.Rank,
+					IncomingRank:  incomingRank,
+				})
+			}
+
 			result, err := PlaceIBKROrder(contract, action, absQty, price)
 			if err != nil {
 				sig.ExecStatus = "failed"
 				sig.ExecError = err.Error()
+				// Clear the tentative dedup entry so the fingerprint can retry.
+				updateOrderState(fp, orderState{})
 				AddSignal(sig)
 				log.Printf("IBKR ORDER FAILED: %s %dx %s strike=%.2f expiry=%s price=%.4f — %v",
 					action, absQty, ticker, strike, sig.ExpirationDate, price, err)
 				return
 			}
 
-			// Record new fingerprint state.
-			s.orderFingerprintsMu.Lock()
-			s.orderFingerprints[fp] = orderState{OrderID: result.OrderID, Status: result.Status}
-			s.orderFingerprintsMu.Unlock()
+			// Commit the real broker state to the dedup map.
+			updateOrderState(fp, orderState{OrderID: result.OrderID, Status: result.Status})
+
+			// Track in pending cap map.
+			sig.SignalRank = incomingRank
+			addPendingOrder(result.OrderID, incomingRank, sig)
 
 			sig.IBKROrderID = result.OrderID
 			sig.ExecStatus = "submitted"
 			AddSignal(sig)
 
-			// Log only when this is genuinely a new order (not a status repeat).
-			if !exists || prev.Status != result.Status {
-				log.Printf("IBKR ORDER PLACED: orderId=%d status=%s symbol=%s strike=%.2f expiry=%s price=%.4f qty=%d",
-					result.OrderID, result.Status, ticker, strike, sig.ExpirationDate, price, absQty)
+			// Log only on genuine new orders (not status repeats).
+			// prev was captured by checkAndMarkOrder before we marked this fp.
+			if prev.Status == "" || prev.Status != result.Status {
+				log.Printf("IBKR ORDER PLACED: orderId=%d status=%s symbol=%s strike=%.2f expiry=%s price=%.4f qty=%d rank=%.3f",
+					result.OrderID, result.Status, ticker, strike, sig.ExpirationDate, price, absQty, incomingRank)
 			}
 
 			// Record in trade log as a real broker order (not a simulated fill).


### PR DESCRIPTION
## Summary

Six commits. Fixes two critical bugs exposed after PR #7 landed, plus adds the pending-order cap feature (user can tune `MAX_PENDING_ORDERS`, default 2) with rank-based replacement so incoming higher-conviction signals can cancel lower-ranked pending orders.

## What's in this PR

### Bug 1 — `ibkr_account` mode normalizer (was blocking /api/account)
- `26bcc67` fix(ibkr_account): accept IBKR_PAPER / PAPER / IBKR_LIVE / LIVE / SIMULATION via `normalize_mode()` helper
- Unblocks the Go engine's shell-out; `/api/account` returns real IBKR NAV again

### Bug 2 — Engine concurrent-map panic (Phase 7 regression)
- `09e5beb` fix(engine): sync.RWMutex around the order dedup map
- Adds `go test -race` coverage so this class can't regress silently

### Feature — Pending-order cap with signal-rank replacement
- `8732789` feat(engine): `MAX_PENDING_ORDERS=2` env cap, in-memory rank map keyed by orderId
- Rank = `0.5 * confidence + 0.3 * min(net_profit/cost, 1) + 0.2 * exp(-age_sec/600)`
- When queue full AND incoming rank > lowest pending rank: cancel lowest, place new, log `[REPLACE]`
- When queue full AND incoming rank ≤ lowest: reject, log `[REJECT-CAP]`, increment Prometheus counter
- `30ade96` feat(ui): pending-cap status badge (N/max, color-graded), rank per row, replacement banner, event feed of last 10 `[REPLACE]` / `[REJECT-CAP]`
- `4587c90` fix(ui): PendingOrderModal TS type cleanup + Playwright timing harden

### Housekeeping
- `e81452e` chore: add `test-results/` and `playwright-report/` to `.gitignore` (caught by Phase 7 screenshot cleanup habit)

## Verification

- All prior tests still pass; new tests added for each fix/feature
- `go test -race ./...` passes (proves mutex fix)
- Pending-cap Playwright spec mocks a full queue and asserts the replacement banner shows
- `/api/account` returns real IBKR paper NAV when Gateway is up (manual smoke-test: NAV \$1,000,863.54)

## Test plan

- [ ] Review commits in order (mode normalizer → mutex → feature → UI → cleanup → gitignore)
- [ ] `go test -race ./...` from `execution_engine/`
- [ ] `pytest alpha_engine/` full suite
- [ ] Visual: reload dashboard, confirm pending-cap badge and rank display
- [ ] Smoke: restart with `MAX_PENDING_ORDERS=1` and verify second signal is rejected/replaces-first

## Follow-ups

- Phase 9 (queued): bracket orders + underlying-price SL + time-based exit (safety gate before live trading)
- Phase 10 (queued): notional-based sizing + archetype config + notional UI control + pre-market panel
- Phase 11 (queued): resume stashed Phase A (DAX/FTSE/N225/HSI/SSE/FX feeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)