### PR TITLE
Stabilization Phase 12 — trade management UI: cancel pending orders + close open positions

### DIFF
--- a/tcode/alpha_control_center/src/pages/Dashboard.tsx
+++ b/tcode/alpha_control_center/src/pages/Dashboard.tsx
@@ -1813,6 +1813,280 @@ function minsUntilExpiryClose(): number {
     return (15 * 60 + 30) - (h * 60 + m);
 }
 
+/** True when US regular session is open (Mon–Fri 9:30–16:00 ET). */
+function isMarketOpen(): boolean {
+    const fmt = new Intl.DateTimeFormat('en-US', {
+        timeZone: 'America/New_York',
+        hour: 'numeric', minute: 'numeric', hour12: false, weekday: 'short',
+    });
+    const parts = fmt.formatToParts(new Date());
+    const h  = parseInt(parts.find(p => p.type === 'hour')?.value ?? '0', 10);
+    const m  = parseInt(parts.find(p => p.type === 'minute')?.value ?? '0', 10);
+    const wd = parts.find(p => p.type === 'weekday')?.value ?? '';
+    if (['Sat', 'Sun'].includes(wd)) return false;
+    const t = h * 60 + m;
+    return t >= 570 && t < 960; // 9:30–16:00 ET
+}
+
+/**
+ * Human-readable label for when the next OPG order will execute.
+ * Returns the ET weekday + "9:30 AM ET" for the next trading day.
+ */
+function nextMarketOpenLabel(): string {
+    const now = new Date();
+    // Advance to next trading day
+    const candidate = new Date(now);
+    candidate.setUTCDate(candidate.getUTCDate() + 1);
+    // Find next Mon–Fri (in UTC approximation is fine for labelling)
+    while ([0, 6].includes(candidate.getDay())) {
+        candidate.setUTCDate(candidate.getUTCDate() + 1);
+    }
+    const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+    return `${days[candidate.getDay()]} 9:30 AM ET`;
+}
+
+// ── Shared toast ──────────────────────────────────────────────────────────────
+
+interface ActionToast {
+    id: number;
+    message: string;
+    kind: 'success' | 'error';
+}
+
+let _toastSeq = 0;
+function makeToast(message: string, kind: ActionToast['kind']): ActionToast {
+    return { id: ++_toastSeq, message, kind };
+}
+
+const ActionToastDisplay = ({ toasts, onRemove }: { toasts: ActionToast[]; onRemove: (id: number) => void }) => (
+    <div style={{ position: 'fixed', bottom: 80, right: 24, zIndex: 10000, display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {toasts.map(t => (
+            <div
+                key={t.id}
+                role="status"
+                aria-live="polite"
+                style={{
+                    background: t.kind === 'success' ? 'rgba(63,185,80,0.15)' : 'rgba(248,81,73,0.15)',
+                    border: `1px solid ${t.kind === 'success' ? 'rgba(63,185,80,0.5)' : 'rgba(248,81,73,0.5)'}`,
+                    borderRadius: 8, padding: '10px 16px',
+                    fontSize: '0.78rem', color: '#c9d1d9', maxWidth: 340,
+                    cursor: 'pointer',
+                }}
+                onClick={() => onRemove(t.id)}
+                title="Click to dismiss"
+            >
+                {t.kind === 'success' ? '✓ ' : '⚠ '}{t.message}
+            </div>
+        ))}
+    </div>
+);
+
+// ── Cancel Order confirm modal ────────────────────────────────────────────────
+
+const CancelOrderModal = ({
+    order,
+    onConfirm,
+    onClose,
+    isLive,
+}: {
+    order: PendingOrder;
+    onConfirm: () => void;
+    onClose: () => void;
+    isLive: boolean;
+}) => {
+    const [countdown, setCountdown] = useState(isLive ? 3 : 0);
+    const [confirming, setConfirming] = useState(false);
+
+    // 3-second live-mode countdown
+    useEffect(() => {
+        if (!isLive || countdown <= 0) return;
+        const id = setTimeout(() => setCountdown(c => c - 1), 1000);
+        return () => clearTimeout(id);
+    }, [isLive, countdown]);
+
+    const handleConfirm = async () => {
+        setConfirming(true);
+        onConfirm();
+    };
+
+    const label = `${order.action} ${orderLabel(order)} × ${order.qty}`;
+    const canConfirm = !isLive || countdown === 0;
+
+    return (
+        <div className="modal-overlay" onClick={onClose} role="dialog" aria-modal="true"
+             aria-label={`Confirm cancel order #${order.orderId}`}>
+            <div className="modal-card fill-drill" onClick={e => e.stopPropagation()} style={{ maxWidth: 420 }}>
+                <div className="modal-header">
+                    <span className="modal-title">Cancel Order #{order.orderId}</span>
+                    <button className="modal-close" onClick={onClose} aria-label="Close cancel dialog">✕</button>
+                </div>
+                <div className="fill-drill-body" style={{ padding: '16px 20px', gap: 12 }}>
+                    <div style={{
+                        background: 'rgba(230,162,0,0.1)', border: '1px solid rgba(230,162,0,0.4)',
+                        borderRadius: 6, padding: '10px 14px', fontSize: '0.85rem', color: '#e6a200',
+                    }}>
+                        Cancel order #{order.orderId} ({label})?
+                    </div>
+                    {isLive && (
+                        <div style={{
+                            background: 'rgba(248,81,73,0.12)', border: '1px solid rgba(248,81,73,0.4)',
+                            borderRadius: 6, padding: '8px 12px', fontSize: '0.78rem', color: '#f85149',
+                        }}>
+                            ⚠ LIVE MODE — this will cancel a real order on your live account.
+                        </div>
+                    )}
+                    <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end', marginTop: 8 }}>
+                        <button
+                            onClick={onClose}
+                            disabled={confirming}
+                            aria-label="Keep the order — do not cancel"
+                            title="Keep order"
+                            style={{
+                                padding: '7px 18px', borderRadius: 6, border: '1px solid #30363d',
+                                background: 'transparent', color: '#8b949e', cursor: 'pointer', fontSize: '0.82rem',
+                            }}
+                        >
+                            Keep
+                        </button>
+                        <button
+                            onClick={handleConfirm}
+                            disabled={!canConfirm || confirming}
+                            aria-label={canConfirm ? 'Confirm cancel order' : `Wait ${countdown}s`}
+                            title={canConfirm ? 'Confirm cancel' : `Enabled in ${countdown}s`}
+                            data-tooltip={canConfirm ? 'Confirm cancel order' : `Available in ${countdown}s (live-mode safety)`}
+                            style={{
+                                padding: '7px 18px', borderRadius: 6, border: 'none',
+                                background: canConfirm ? 'rgba(230,162,0,0.9)' : 'rgba(230,162,0,0.3)',
+                                color: canConfirm ? '#0d1117' : '#8b949e',
+                                cursor: canConfirm ? 'pointer' : 'not-allowed',
+                                fontSize: '0.82rem', fontWeight: 600, transition: 'all 0.2s',
+                            }}
+                        >
+                            {isLive && countdown > 0 ? `Confirm (${countdown}s)` : 'Confirm Cancel'}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+// ── Close Position confirm modal ──────────────────────────────────────────────
+
+interface ScheduledClose {
+    orderId: number;
+    scheduledFor: string;  // ISO8601 UTC from API
+}
+
+const ClosePositionModal = ({
+    pos,
+    onConfirm,
+    onClose,
+    isLive,
+}: {
+    pos: IBKRPosition;
+    onConfirm: () => void;
+    onClose: () => void;
+    isLive: boolean;
+}) => {
+    const [marketOpen] = useState(() => isMarketOpen());
+    const [countdown, setCountdown] = useState(isLive ? 3 : 0);
+    const [confirming, setConfirming] = useState(false);
+
+    useEffect(() => {
+        if (!isLive || countdown <= 0) return;
+        const id = setTimeout(() => setCountdown(c => c - 1), 1000);
+        return () => clearTimeout(id);
+    }, [isLive, countdown]);
+
+    const handleConfirm = () => {
+        setConfirming(true);
+        onConfirm();
+    };
+
+    const label = pos.option_type
+        ? `${pos.ticker} $${pos.strike}${pos.option_type[0]} ${pos.expiration}`
+        : pos.ticker;
+    const canConfirm = !isLive || countdown === 0;
+
+    return (
+        <div className="modal-overlay" onClick={onClose} role="dialog" aria-modal="true"
+             aria-label={`Confirm close position ${label}`}>
+            <div className="modal-card fill-drill" onClick={e => e.stopPropagation()} style={{ maxWidth: 440 }}>
+                <div className="modal-header">
+                    <span className="modal-title">Close Position</span>
+                    <button className="modal-close" onClick={onClose} aria-label="Close position dialog">✕</button>
+                </div>
+                <div className="fill-drill-body" style={{ padding: '16px 20px', gap: 12 }}>
+                    <div style={{
+                        background: 'rgba(88,166,255,0.08)', border: '1px solid rgba(88,166,255,0.3)',
+                        borderRadius: 6, padding: '10px 14px', fontSize: '0.85rem', color: '#c9d1d9',
+                    }}>
+                        Close position <strong>{label}</strong> × {pos.qty}?
+                    </div>
+
+                    {/* Market hours warning */}
+                    {marketOpen ? (
+                        <div style={{
+                            background: 'rgba(63,185,80,0.1)', border: '1px solid rgba(63,185,80,0.4)',
+                            borderRadius: 6, padding: '8px 12px', fontSize: '0.78rem', color: '#3fb950',
+                        }}>
+                            <strong>Market open</strong> — Order will execute immediately as MKT DAY.
+                        </div>
+                    ) : (
+                        <div style={{
+                            background: 'rgba(230,162,0,0.1)', border: '1px solid rgba(230,162,0,0.4)',
+                            borderRadius: 6, padding: '8px 12px', fontSize: '0.78rem', color: '#e6a200',
+                        }}>
+                            <strong>Market closed</strong> — Order will queue for {nextMarketOpenLabel()} open (MKT OPG).
+                        </div>
+                    )}
+
+                    {isLive && (
+                        <div style={{
+                            background: 'rgba(248,81,73,0.12)', border: '1px solid rgba(248,81,73,0.4)',
+                            borderRadius: 6, padding: '8px 12px', fontSize: '0.78rem', color: '#f85149',
+                        }}>
+                            ⚠ LIVE MODE — this will close a real position on your live account.
+                        </div>
+                    )}
+
+                    <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end', marginTop: 8 }}>
+                        <button
+                            onClick={onClose}
+                            disabled={confirming}
+                            aria-label="Keep position open"
+                            title="Keep position"
+                            style={{
+                                padding: '7px 18px', borderRadius: 6, border: '1px solid #30363d',
+                                background: 'transparent', color: '#8b949e', cursor: 'pointer', fontSize: '0.82rem',
+                            }}
+                        >
+                            Keep
+                        </button>
+                        <button
+                            onClick={handleConfirm}
+                            disabled={!canConfirm || confirming}
+                            aria-label={canConfirm ? 'Confirm close position' : `Wait ${countdown}s`}
+                            title={canConfirm ? 'Confirm close' : `Enabled in ${countdown}s`}
+                            data-tooltip={canConfirm ? 'Confirm close position' : `Available in ${countdown}s (live-mode safety)`}
+                            style={{
+                                padding: '7px 18px', borderRadius: 6, border: 'none',
+                                background: canConfirm ? 'rgba(248,81,73,0.9)' : 'rgba(248,81,73,0.3)',
+                                color: canConfirm ? '#fff' : '#8b949e',
+                                cursor: canConfirm ? 'pointer' : 'not-allowed',
+                                fontSize: '0.82rem', fontWeight: 600, transition: 'all 0.2s',
+                            }}
+                        >
+                            {isLive && countdown > 0 ? `Close (${countdown}s)` : 'Confirm Close'}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
 const PendingOrderModal = ({ order, onClose }: { order: PendingOrder; onClose: () => void }) => {
     // Approximate rank breakdown for display (mirrors computeRank in subscriber.go).
     const rankBreakdown = order.rank != null ? { total: order.rank } : null;
@@ -1884,15 +2158,71 @@ const PendingOrdersPanel = ({
     source,
     capEvents,
     replacementToast,
+    executionMode,
+    onOrderCancelled,
 }: {
     orders: PendingOrdersResponse | null;
     source: string;
     capEvents: CapEvent[];
     replacementToast: CapEvent | null;
+    executionMode: string;
+    onOrderCancelled: () => void;
 }) => {
     const [selectedOrder, setSelectedOrder] = useState<PendingOrder | null>(null);
+    const [cancelModal, setCancelModal] = useState<PendingOrder | null>(null);
+    const [cancellingId, setCancellingId] = useState<number | null>(null);
+    const cancelLastMsRef = useRef<number>(0);
+    const [toasts, setToasts] = useState<ActionToast[]>([]);
     const [cancelledOpen, setCancelledOpen] = useState(false);
     const [eventsOpen, setEventsOpen] = useState(false);
+
+    const isLive = executionMode === 'IBKR_LIVE';
+
+    const removeToast = useCallback((id: number) => {
+        setToasts(ts => ts.filter(t => t.id !== id));
+    }, []);
+
+    const pushToast = useCallback((message: string, kind: ActionToast['kind']) => {
+        const t = makeToast(message, kind);
+        setToasts(ts => [...ts, t]);
+        setTimeout(() => removeToast(t.id), 6000);
+    }, [removeToast]);
+
+    const handleCancelClick = useCallback((order: PendingOrder, e: React.MouseEvent) => {
+        e.stopPropagation();
+        const now = Date.now();
+        if (now - cancelLastMsRef.current < 3000 && cancelLastMsRef.current > 0) {
+            // Double-tap protection: ignore second click within 3s
+            return;
+        }
+        cancelLastMsRef.current = now;
+        setCancelModal(order);
+    }, []);
+
+    const handleCancelConfirm = useCallback(async () => {
+        if (!cancelModal) return;
+        const order = cancelModal;
+        setCancelModal(null);
+        setCancellingId(order.orderId);
+        try {
+            const r = await fetch('/api/orders/cancel', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ order_id: order.orderId }),
+            });
+            const data = await r.json();
+            if (!r.ok || data.error) {
+                pushToast(`Cancel failed: ${data.error ?? r.statusText}`, 'error');
+            } else {
+                pushToast(`Order #${order.orderId} cancelled`, 'success');
+                onOrderCancelled();
+            }
+        } catch (err) {
+            pushToast(`Cancel error: ${String(err)}`, 'error');
+        } finally {
+            setCancellingId(null);
+        }
+    }, [cancelModal, pushToast, onOrderCancelled]);
 
     const active    = orders?.active    ?? [];
     const cancelled = orders?.cancelled ?? [];
@@ -1926,6 +2256,15 @@ const PendingOrdersPanel = ({
             {selectedOrder && (
                 <PendingOrderModal order={selectedOrder} onClose={() => setSelectedOrder(null)} />
             )}
+            {cancelModal && (
+                <CancelOrderModal
+                    order={cancelModal}
+                    onConfirm={handleCancelConfirm}
+                    onClose={() => setCancelModal(null)}
+                    isLive={isLive}
+                />
+            )}
+            <ActionToastDisplay toasts={toasts} onRemove={removeToast} />
 
             {/* Replacement toast */}
             {replacementToast && (
@@ -2022,6 +2361,30 @@ const PendingOrdersPanel = ({
                                         rank: {o.rank.toFixed(2)}
                                     </span>
                                 )}
+                                {/* Cancel button — amber, not red; cancellation is neutral */}
+                                <button
+                                    className="cancel-order-btn"
+                                    aria-label={`Cancel order #${o.orderId} — ${orderLabel(o)}`}
+                                    title="Cancel this pending order"
+                                    data-tooltip={`Cancel order #${o.orderId}`}
+                                    disabled={cancellingId === o.orderId}
+                                    onClick={e => handleCancelClick(o, e)}
+                                    onKeyDown={e => { if (e.key === 'Enter') { e.stopPropagation(); handleCancelClick(o, e as unknown as React.MouseEvent); } }}
+                                    style={{
+                                        marginLeft: 'auto',
+                                        padding: '2px 10px',
+                                        borderRadius: 4,
+                                        border: '1px solid rgba(230,162,0,0.5)',
+                                        background: 'rgba(230,162,0,0.1)',
+                                        color: cancellingId === o.orderId ? '#8b949e' : '#e6a200',
+                                        cursor: cancellingId === o.orderId ? 'not-allowed' : 'pointer',
+                                        fontSize: '0.7rem',
+                                        fontWeight: 600,
+                                        flexShrink: 0,
+                                    }}
+                                >
+                                    {cancellingId === o.orderId ? '…' : '✕ Cancel'}
+                                </button>
                             </div>
                             <div className="pending-order-detail">
                                 <span>×{o.qty}</span>
@@ -2109,14 +2472,94 @@ const TradingFloor = ({  // Column C in 4-col grid
     portfolio,
     ibkrPositions,
     brokerStatus,
+    executionMode,
 }: {
     portfolio: Portfolio;
     ibkrPositions: IBKRPosition[];
     brokerStatus: BrokerStatus | null;
+    executionMode: string;
 }) => {
     const [selectedPos, setSelectedPos] = useState<IBKRPosition | null>(null);
     const prevPnlRef = useRef<Record<string, number>>({});
     const [flipKeys, setFlipKeys] = useState<Set<string>>(new Set());
+
+    // Close position state
+    const [closeModal, setCloseModal] = useState<{ pos: IBKRPosition; key: string } | null>(null);
+    const [closingKey, setClosingKey] = useState<string | null>(null);
+    const closeLastMsRef = useRef<number>(0);
+    const [scheduledCloses, setScheduledCloses] = useState<Record<string, ScheduledClose>>({});
+    const [closeToasts, setCloseToasts] = useState<ActionToast[]>([]);
+
+    const isLive = executionMode === 'IBKR_LIVE';
+
+    const removeCloseToast = useCallback((id: number) => setCloseToasts(ts => ts.filter(t => t.id !== id)), []);
+    const pushCloseToast = useCallback((message: string, kind: ActionToast['kind']) => {
+        const t = makeToast(message, kind);
+        setCloseToasts(ts => [...ts, t]);
+        setTimeout(() => removeCloseToast(t.id), 7000);
+    }, [removeCloseToast]);
+
+    const handleCloseClick = useCallback((pos: IBKRPosition, key: string, e: React.MouseEvent) => {
+        e.stopPropagation();
+        const now = Date.now();
+        if (now - closeLastMsRef.current < 3000 && closeLastMsRef.current > 0) return; // double-tap guard
+        closeLastMsRef.current = now;
+        setCloseModal({ pos, key });
+    }, []);
+
+    const handleCloseConfirm = useCallback(async () => {
+        if (!closeModal) return;
+        const { pos, key } = closeModal;
+        setCloseModal(null);
+        setClosingKey(key);
+        // contract_key: SYMBOL_OPTIONTYPE_EXPIRY_STRIKE
+        const contractKey = `${pos.ticker}_${pos.option_type}_${pos.expiration}_${pos.strike}`;
+        try {
+            const r = await fetch('/api/positions/close', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    contract_key: contractKey,
+                    quantity: pos.qty,
+                    market_open_if_closed: true,
+                }),
+            });
+            const data: { order_id?: number; status?: string; scheduled_for?: string | null; error?: string } = await r.json();
+            if (!r.ok || data.error) {
+                pushCloseToast(`Close failed: ${data.error ?? r.statusText}`, 'error');
+            } else if (data.scheduled_for) {
+                // OPG-scheduled: record the badge
+                setScheduledCloses(sc => ({ ...sc, [key]: { orderId: data.order_id!, scheduledFor: data.scheduled_for! } }));
+                pushCloseToast(`Close scheduled for ${nextMarketOpenLabel()} (order #${data.order_id})`, 'success');
+            } else {
+                pushCloseToast(`Position close submitted (order #${data.order_id})`, 'success');
+            }
+        } catch (err) {
+            pushCloseToast(`Close error: ${String(err)}`, 'error');
+        } finally {
+            setClosingKey(null);
+        }
+    }, [closeModal, pushCloseToast]);
+
+    const handleCancelSchedule = useCallback(async (key: string, sc: ScheduledClose, e: React.MouseEvent) => {
+        e.stopPropagation();
+        try {
+            const r = await fetch('/api/orders/cancel', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ order_id: sc.orderId }),
+            });
+            const data = await r.json();
+            if (!r.ok || data.error) {
+                pushCloseToast(`Cancel schedule failed: ${data.error ?? r.statusText}`, 'error');
+            } else {
+                setScheduledCloses(sc2 => { const n = { ...sc2 }; delete n[key]; return n; });
+                pushCloseToast(`Scheduled close #${sc.orderId} cancelled`, 'success');
+            }
+        } catch (err) {
+            pushCloseToast(`Cancel schedule error: ${String(err)}`, 'error');
+        }
+    }, [pushCloseToast]);
 
     const useIBKR = ibkrPositions.length > 0;
     // Show sim positions when no IBKR positions (IBKR client is a stub, sim positions are the real activity)
@@ -2151,6 +2594,15 @@ const TradingFloor = ({  // Column C in 4-col grid
     return (
         <>
             {selectedPos && <PositionModal pos={selectedPos} onClose={() => setSelectedPos(null)} />}
+            {closeModal && (
+                <ClosePositionModal
+                    pos={closeModal.pos}
+                    onConfirm={handleCloseConfirm}
+                    onClose={() => setCloseModal(null)}
+                    isLive={isLive}
+                />
+            )}
+            <ActionToastDisplay toasts={closeToasts} onRemove={removeCloseToast} />
             <div className="dash-col card" role="region" aria-label="Trading Floor — open positions">
                 <div className="section-header">
                     <Tooltip text="Open positions from live IBKR paper account. Click any card for drill-down.">
@@ -2180,6 +2632,8 @@ const TradingFloor = ({  // Column C in 4-col grid
                             const pnlPct = pos.avg_cost > 0
                                 ? ((pos.current_price - pos.avg_cost) / pos.avg_cost * 100)
                                 : 0;
+                            const isClosing = closingKey === key;
+                            const sc = scheduledCloses[key];
                             return (
                                 <div
                                     key={key}
@@ -2198,6 +2652,28 @@ const TradingFloor = ({  // Column C in 4-col grid
                                         <Tooltip text={`${pos.qty} contract${Math.abs(pos.qty) !== 1 ? 's' : ''} held`}>
                                             <span className="qty-badge">×{pos.qty}</span>
                                         </Tooltip>
+                                        {/* Close position button */}
+                                        <button
+                                            className="close-position-btn"
+                                            aria-label={`Close position ${label} × ${pos.qty}`}
+                                            title="Close this position"
+                                            data-tooltip={`Close position — ${isMarketOpen() ? 'MKT DAY immediate' : 'schedules OPG for next open'}`}
+                                            disabled={isClosing || !!sc}
+                                            onClick={e => handleCloseClick(pos, key, e)}
+                                            onKeyDown={e => { if (e.key === 'Enter') { e.stopPropagation(); handleCloseClick(pos, key, e as unknown as React.MouseEvent); } }}
+                                            style={{
+                                                marginLeft: 'auto',
+                                                padding: '2px 10px',
+                                                borderRadius: 4,
+                                                border: '1px solid rgba(248,81,73,0.4)',
+                                                background: 'rgba(248,81,73,0.1)',
+                                                color: (isClosing || !!sc) ? '#8b949e' : '#f85149',
+                                                cursor: (isClosing || !!sc) ? 'not-allowed' : 'pointer',
+                                                fontSize: '0.7rem', fontWeight: 600, flexShrink: 0,
+                                            }}
+                                        >
+                                            {isClosing ? '…' : '× Close'}
+                                        </button>
                                     </div>
                                     <div className="position-stats">
                                         <div className="pos-stat">
@@ -2225,6 +2701,37 @@ const TradingFloor = ({  // Column C in 4-col grid
                                             </span>
                                         </Tooltip>
                                     </div>
+                                    {/* Scheduled-close badge — shown when an OPG close is queued */}
+                                    {sc && (
+                                        <div
+                                            style={{
+                                                display: 'flex', alignItems: 'center', gap: 6,
+                                                marginTop: 4, padding: '4px 8px',
+                                                background: 'rgba(230,162,0,0.1)',
+                                                border: '1px solid rgba(230,162,0,0.4)',
+                                                borderRadius: 4, fontSize: '0.7rem', color: '#e6a200',
+                                            }}
+                                            aria-label={`Scheduled close: ${nextMarketOpenLabel()} order #${sc.orderId}`}
+                                        >
+                                            <Tooltip text={`OPG order #${sc.orderId} scheduled for ${nextMarketOpenLabel()} opening auction`}>
+                                                <span>⏰ Scheduled close: {nextMarketOpenLabel()} (#{sc.orderId})</span>
+                                            </Tooltip>
+                                            <button
+                                                aria-label={`Cancel scheduled close order #${sc.orderId}`}
+                                                title="Cancel the scheduled close order"
+                                                data-tooltip={`Cancel scheduled close #${sc.orderId}`}
+                                                onClick={e => handleCancelSchedule(key, sc, e)}
+                                                style={{
+                                                    marginLeft: 'auto', padding: '1px 7px', borderRadius: 3,
+                                                    border: '1px solid rgba(230,162,0,0.5)',
+                                                    background: 'transparent', color: '#e6a200',
+                                                    cursor: 'pointer', fontSize: '0.68rem',
+                                                }}
+                                            >
+                                                ✕
+                                            </button>
+                                        </div>
+                                    )}
                                     {pos.catalyst && (
                                         <div className="position-catalyst">
                                             <span className="catalyst-model">{pos.model_id}</span>
@@ -3872,8 +4379,15 @@ const Dashboard = ({ brokerStatus, integrityRed = false }: { brokerStatus: Broke
                     source={pendingOrders?.source ?? ''}
                     capEvents={capEvents}
                     replacementToast={replacementToast}
+                    executionMode={brokerStatus?.mode ?? pendingOrders?.source ?? 'IBKR_PAPER'}
+                    onOrderCancelled={fetchPendingOrders}
                 />
-                <TradingFloor portfolio={portfolio} ibkrPositions={ibkrPositions} brokerStatus={brokerStatus} />
+                <TradingFloor
+                    portfolio={portfolio}
+                    ibkrPositions={ibkrPositions}
+                    brokerStatus={brokerStatus}
+                    executionMode={brokerStatus?.mode ?? pendingOrders?.source ?? 'IBKR_PAPER'}
+                />
                 <ExecutionLog trades={trades} brokerStatus={brokerStatus} lossSummary={lossSummary} simMode={simMode} />
             </div>
 

--- a/tcode/alpha_control_center/tests/ux_cancel_close_controls.spec.ts
+++ b/tcode/alpha_control_center/tests/ux_cancel_close_controls.spec.ts
@@ -1,0 +1,410 @@
+/**
+ * UX Test: Cancel Pending Order + Close Position — Phase 12
+ *
+ * Verifies the trade management UI features:
+ *  - Pending order rows show a "✕ Cancel" button
+ *  - Click → confirm modal → confirm → success toast → pending list refreshes
+ *  - Position rows show a "× Close" button
+ *  - Click when market closed → modal mentions scheduled open (MKT OPG)
+ *  - Click when market open (mock time to Tuesday 13:30 UTC) → modal mentions MKT DAY
+ *  - Double-click protection: second click within 3s is ignored
+ *  - Live-mode (IBKR_LIVE): confirm button shows countdown before enabling
+ *  - Scheduled-close badge appears on position when OPG order is returned
+ *
+ * All tests use route interception — no live IBKR gateway required.
+ */
+
+import { test, expect, Page } from '@playwright/test';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:2112';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makePendingOrder(overrides: object = {}) {
+    return {
+        orderId: 1001,
+        status: 'Submitted',
+        symbol: 'TSLA',
+        action: 'BUY',
+        qty: 5,
+        strike: 365,
+        expiry: '2026-04-17',
+        option_type: 'CALL',
+        limit_price: 0.28,
+        filled_qty: 0,
+        avg_fill_price: 0,
+        timestamp: new Date().toISOString(),
+        rank: 0.72,
+        ...overrides,
+    };
+}
+
+function makeIBKRPosition(overrides: object = {}) {
+    return {
+        ticker: 'TSLA',
+        sec_type: 'OPT',
+        qty: 5,
+        avg_cost: 0.28,
+        current_price: 0.35,
+        unrealized_pnl: 35.0,
+        market_value: 175.0,
+        option_type: 'CALL',
+        strike: 365,
+        expiration: '2026-04-17',
+        delta: 0.3,
+        iv: 0.65,
+        signal_id: 'sig-001',
+        catalyst: 'Bullish momentum + congression',
+        model_id: 'TSM-A',
+        ...overrides,
+    };
+}
+
+async function setupBaseRoutes(page: Page, {
+    pendingOrders,
+    ibkrPositions,
+    cancelResult,
+    closeResult,
+    brokerMode = 'IBKR_PAPER',
+}: {
+    pendingOrders: object;
+    ibkrPositions: object[];
+    cancelResult?: object;
+    closeResult?: object;
+    brokerMode?: string;
+}) {
+    await page.route('**/api/orders/pending', (route) =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(pendingOrders) })
+    );
+    await page.route('**/api/orders/cap-events', (route) =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ events: [], ranks: [], cap: 2, pending_cnt: 1 }) })
+    );
+    await page.route('**/api/positions', (route) =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(ibkrPositions) })
+    );
+    await page.route('**/api/account', (route) =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({
+            net_liquidation: 50000, cash_balance: 48000, unrealized_pnl: 35.0,
+            realized_pnl: 0, buying_power: 96000, equity_with_loan: 50000, ts: new Date().toISOString(),
+            source: brokerMode,
+        })})
+    );
+    await page.route('**/api/broker/status', (route) =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({
+            mode: brokerMode, broker: 'IBKR', connected: true,
+        })})
+    );
+    if (cancelResult !== undefined) {
+        await page.route('**/api/orders/cancel', (route) =>
+            route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(cancelResult) })
+        );
+    }
+    if (closeResult !== undefined) {
+        await page.route('**/api/positions/close', (route) =>
+            route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(closeResult) })
+        );
+    }
+}
+
+async function waitForPendingPanel(page: Page) {
+    const panel = page.locator('[role="region"][aria-label*="Pending Orders"]');
+    await panel.waitFor({ state: 'visible', timeout: 20_000 });
+    return panel;
+}
+
+async function waitForPositionsPanel(page: Page) {
+    const panel = page.locator('[role="region"][aria-label*="Trading Floor"]');
+    await panel.waitFor({ state: 'visible', timeout: 20_000 });
+    return panel;
+}
+
+// ── Cancel button on Pending Orders ──────────────────────────────────────────
+
+test.describe('Cancel Pending Order', () => {
+    test('pending order row shows ✕ Cancel button', async ({ page }) => {
+        const pendingOrders = { active: [makePendingOrder()], cancelled: [], source: 'IBKR_PAPER', cap: 2 };
+        await setupBaseRoutes(page, { pendingOrders, ibkrPositions: [] });
+
+        await page.goto(BASE_URL, { waitUntil: 'load' });
+        const panel = await waitForPendingPanel(page);
+
+        // Wait for the active orders to render (fetchPendingOrders fires 2s after mount)
+        const cancelBtn = panel.locator('[aria-label*="Cancel order #1001"]');
+        await expect(cancelBtn).toBeVisible({ timeout: 20_000 });
+        await expect(cancelBtn).toContainText('Cancel');
+    });
+
+    test('cancel button click shows confirmation modal', async ({ page }) => {
+        const pendingOrders = { active: [makePendingOrder()], cancelled: [], source: 'IBKR_PAPER', cap: 2 };
+        await setupBaseRoutes(page, {
+            pendingOrders, ibkrPositions: [],
+            cancelResult: { order_id: 1001, status: 'Cancelled', oca_cancelled: [], timestamp: new Date().toISOString() },
+        });
+
+        await page.goto(BASE_URL, { waitUntil: 'load' });
+        const panel = await waitForPendingPanel(page);
+
+        const cancelBtn = panel.locator('[aria-label*="Cancel order #1001"]');
+        await cancelBtn.waitFor({ state: 'visible', timeout: 20_000 });
+        await cancelBtn.click({ force: true });
+
+        // Confirm modal should appear
+        const modal = page.locator('[role="dialog"][aria-label*="Confirm cancel order"]');
+        await expect(modal).toBeVisible({ timeout: 5_000 });
+        await expect(modal).toContainText('Cancel Order #1001');
+    });
+
+    test('confirm cancel → success toast appears', async ({ page }) => {
+        const pendingOrders = { active: [makePendingOrder()], cancelled: [], source: 'IBKR_PAPER', cap: 2 };
+        await setupBaseRoutes(page, {
+            pendingOrders, ibkrPositions: [],
+            cancelResult: { order_id: 1001, status: 'Cancelled', oca_cancelled: [], timestamp: new Date().toISOString() },
+        });
+
+        await page.goto(BASE_URL, { waitUntil: 'load' });
+        const panel = await waitForPendingPanel(page);
+
+        const cancelBtn = panel.locator('[aria-label*="Cancel order #1001"]');
+        await cancelBtn.waitFor({ state: 'visible', timeout: 20_000 });
+        await cancelBtn.click({ force: true });
+
+        const modal = page.locator('[role="dialog"][aria-label*="Confirm cancel order"]');
+        await modal.waitFor({ state: 'visible', timeout: 5_000 });
+
+        // Click the "Confirm Cancel" button
+        const confirmBtn = modal.locator('button[aria-label*="Confirm cancel order"]');
+        await confirmBtn.waitFor({ state: 'visible', timeout: 3_000 });
+        await confirmBtn.click({ force: true });
+
+        // Success toast
+        const toast = page.locator('[role="status"]').filter({ hasText: '#1001 cancelled' });
+        await expect(toast).toBeVisible({ timeout: 8_000 });
+    });
+
+    test('double-click protection: second cancel click within 3s is ignored', async ({ page }) => {
+        const pendingOrders = { active: [makePendingOrder()], cancelled: [], source: 'IBKR_PAPER', cap: 2 };
+        await setupBaseRoutes(page, {
+            pendingOrders, ibkrPositions: [],
+            cancelResult: { order_id: 1001, status: 'Cancelled', oca_cancelled: [], timestamp: new Date().toISOString() },
+        });
+
+        await page.goto(BASE_URL, { waitUntil: 'load' });
+        const panel = await waitForPendingPanel(page);
+        const cancelBtn = panel.locator('[aria-label*="Cancel order #1001"]');
+        await cancelBtn.waitFor({ state: 'visible', timeout: 20_000 });
+
+        // First click opens modal
+        await cancelBtn.click({ force: true });
+        const modal = page.locator('[role="dialog"][aria-label*="Confirm cancel order"]');
+        await modal.waitFor({ state: 'visible', timeout: 5_000 });
+
+        // Close modal
+        await modal.locator('button[aria-label="Close cancel dialog"]').click({ force: true });
+        await modal.waitFor({ state: 'hidden', timeout: 3_000 });
+
+        // Immediate second click should be blocked by the 3s guard — modal should NOT open again
+        await cancelBtn.click({ force: true });
+        // Wait a short time to confirm the modal doesn't appear
+        await page.waitForTimeout(500);
+        await expect(modal).not.toBeVisible();
+    });
+});
+
+// ── Close Position button ─────────────────────────────────────────────────────
+
+test.describe('Close Position', () => {
+    test('position row shows × Close button', async ({ page }) => {
+        const pendingOrders = { active: [], cancelled: [], source: 'IBKR_PAPER', cap: 2 };
+        const ibkrPositions = [makeIBKRPosition()];
+        await setupBaseRoutes(page, { pendingOrders, ibkrPositions });
+
+        await page.goto(BASE_URL, { waitUntil: 'load' });
+        const panel = await waitForPositionsPanel(page);
+
+        const closeBtn = panel.locator('[aria-label*="Close position TSLA"]');
+        await expect(closeBtn).toBeVisible({ timeout: 20_000 });
+        await expect(closeBtn).toContainText('Close');
+    });
+
+    test('close click when market closed → modal mentions scheduled open', async ({ page }) => {
+        // Force market-closed by mocking time to Saturday UTC
+        await page.addInitScript(() => {
+            const OrigDate = window.Date;
+            // Saturday 2026-04-18 12:00 UTC
+            const FIXED = new OrigDate('2026-04-18T12:00:00Z').getTime();
+            window.Date = class extends OrigDate {
+                constructor(...args: any[]) {
+                    if (args.length === 0) { super(FIXED); } else { super(...args as [any]); }
+                }
+                static now() { return FIXED; }
+            } as any;
+        });
+
+        const pendingOrders = { active: [], cancelled: [], source: 'IBKR_PAPER', cap: 2 };
+        const ibkrPositions = [makeIBKRPosition()];
+        await setupBaseRoutes(page, {
+            pendingOrders, ibkrPositions,
+            closeResult: {
+                order_id: 42, status: 'PendingSubmit',
+                scheduled_for: '2026-04-20T13:30:00Z', timestamp: new Date().toISOString(),
+            },
+        });
+
+        await page.goto(BASE_URL, { waitUntil: 'load' });
+        const panel = await waitForPositionsPanel(page);
+
+        const closeBtn = panel.locator('[aria-label*="Close position TSLA"]');
+        await closeBtn.waitFor({ state: 'visible', timeout: 20_000 });
+        await closeBtn.click({ force: true });
+
+        // Modal should mention "Market closed" and OPG scheduling
+        const modal = page.locator('[role="dialog"][aria-label*="Confirm close position"]');
+        await modal.waitFor({ state: 'visible', timeout: 5_000 });
+        await expect(modal).toContainText('Market closed');
+        await expect(modal).toContainText('MKT OPG');
+    });
+
+    test('close click when market open → modal mentions MKT DAY', async ({ page }) => {
+        // Force market-open: Tuesday 2026-04-15 17:30 UTC = 13:30 ET (market open)
+        await page.addInitScript(() => {
+            const OrigDate = window.Date;
+            const FIXED = new OrigDate('2026-04-15T17:30:00Z').getTime();
+            window.Date = class extends OrigDate {
+                constructor(...args: any[]) {
+                    if (args.length === 0) { super(FIXED); } else { super(...args as [any]); }
+                }
+                static now() { return FIXED; }
+            } as any;
+        });
+
+        const pendingOrders = { active: [], cancelled: [], source: 'IBKR_PAPER', cap: 2 };
+        const ibkrPositions = [makeIBKRPosition()];
+        await setupBaseRoutes(page, {
+            pendingOrders, ibkrPositions,
+            closeResult: {
+                order_id: 55, status: 'Submitted',
+                scheduled_for: null, timestamp: new Date().toISOString(),
+            },
+        });
+
+        await page.goto(BASE_URL, { waitUntil: 'load' });
+        const panel = await waitForPositionsPanel(page);
+
+        const closeBtn = panel.locator('[aria-label*="Close position TSLA"]');
+        await closeBtn.waitFor({ state: 'visible', timeout: 20_000 });
+        await closeBtn.click({ force: true });
+
+        const modal = page.locator('[role="dialog"][aria-label*="Confirm close position"]');
+        await modal.waitFor({ state: 'visible', timeout: 5_000 });
+        await expect(modal).toContainText('Market open');
+        await expect(modal).toContainText('MKT DAY');
+    });
+
+    test('close double-click protection: button disabled while close is in-flight', async ({ page }) => {
+        // The 3s ref-guard (same pattern as cancel) is proven via the cancel test.
+        // Here we verify the complementary protection: the "× Close" button becomes
+        // disabled (closingKey === key) while a /api/positions/close fetch is in-flight,
+        // preventing a second submission before the first completes.
+        const pendingOrders = { active: [], cancelled: [], source: 'IBKR_PAPER', cap: 2 };
+        const ibkrPositions = [makeIBKRPosition()];
+
+        // Slow response: stalls for 3s so we can observe the disabled state
+        await page.route('**/api/positions/close', async (route) => {
+            await new Promise(r => setTimeout(r, 3000));
+            await route.fulfill({
+                status: 200, contentType: 'application/json',
+                body: JSON.stringify({ order_id: 55, status: 'Submitted', scheduled_for: null, timestamp: new Date().toISOString() }),
+            });
+        });
+        await setupBaseRoutes(page, { pendingOrders, ibkrPositions });
+
+        await page.goto(BASE_URL, { waitUntil: 'load' });
+        const panel = await waitForPositionsPanel(page);
+
+        const closeBtn = panel.locator('[aria-label*="Close position TSLA"]');
+        await closeBtn.waitFor({ state: 'visible', timeout: 20_000 });
+
+        // Click close button → modal opens
+        await closeBtn.click({ force: true });
+        const modal = page.locator('[role="dialog"][aria-label*="Confirm close position"]');
+        await modal.waitFor({ state: 'visible', timeout: 5_000 });
+
+        // Confirm the close → triggers slow fetch, button enters disabled state
+        const confirmBtn = modal.locator('button[aria-label="Confirm close position"]');
+        await confirmBtn.waitFor({ state: 'visible', timeout: 5_000 });
+        await confirmBtn.click({ force: true });
+
+        // While fetch is in-flight: close button must be disabled
+        await expect(closeBtn).toBeDisabled({ timeout: 2_000 });
+    });
+
+    test('live-mode: confirm button shows 3s countdown before enabling', async ({ page }) => {
+        const pendingOrders = { active: [], cancelled: [], source: 'IBKR_LIVE', cap: 2 };
+        const ibkrPositions = [makeIBKRPosition()];
+        await setupBaseRoutes(page, {
+            pendingOrders, ibkrPositions,
+            brokerMode: 'IBKR_LIVE',
+            closeResult: { order_id: 99, status: 'Submitted', scheduled_for: null, timestamp: new Date().toISOString() },
+        });
+
+        await page.goto(BASE_URL, { waitUntil: 'load' });
+        const panel = await waitForPositionsPanel(page);
+
+        const closeBtn = panel.locator('[aria-label*="Close position TSLA"]');
+        await closeBtn.waitFor({ state: 'visible', timeout: 20_000 });
+        await closeBtn.click({ force: true });
+
+        const modal = page.locator('[role="dialog"][aria-label*="Confirm close position"]');
+        await modal.waitFor({ state: 'visible', timeout: 5_000 });
+
+        // Confirm button should initially be disabled with countdown text
+        const confirmBtn = modal.locator('button[aria-label*="Wait"]');
+        await expect(confirmBtn).toBeVisible({ timeout: 3_000 });
+        await expect(confirmBtn).toBeDisabled();
+        const btnText = await confirmBtn.textContent();
+        expect(btnText).toMatch(/Close \(\d+s\)/);
+    });
+
+    test('confirm close → scheduled-close badge appears on position card', async ({ page }) => {
+        // Force market-closed (Saturday)
+        await page.addInitScript(() => {
+            const OrigDate = window.Date;
+            const FIXED = new OrigDate('2026-04-19T12:00:00Z').getTime();
+            window.Date = class extends OrigDate {
+                constructor(...args: any[]) {
+                    if (args.length === 0) { super(FIXED); } else { super(...args as [any]); }
+                }
+                static now() { return FIXED; }
+            } as any;
+        });
+
+        const pendingOrders = { active: [], cancelled: [], source: 'IBKR_PAPER', cap: 2 };
+        const ibkrPositions = [makeIBKRPosition()];
+        await setupBaseRoutes(page, {
+            pendingOrders, ibkrPositions,
+            closeResult: {
+                order_id: 42, status: 'PendingSubmit',
+                scheduled_for: '2026-04-21T13:30:00Z', timestamp: new Date().toISOString(),
+            },
+        });
+
+        await page.goto(BASE_URL, { waitUntil: 'load' });
+        const panel = await waitForPositionsPanel(page);
+
+        const closeBtn = panel.locator('[aria-label*="Close position TSLA"]');
+        await closeBtn.waitFor({ state: 'visible', timeout: 20_000 });
+        await closeBtn.click({ force: true });
+
+        const modal = page.locator('[role="dialog"][aria-label*="Confirm close position"]');
+        await modal.waitFor({ state: 'visible', timeout: 5_000 });
+
+        const confirmBtn = modal.locator('button[aria-label="Confirm close position"]');
+        await confirmBtn.waitFor({ state: 'visible', timeout: 8_000 });
+        await confirmBtn.click({ force: true });
+
+        // Scheduled-close badge should appear on the position card
+        const badge = panel.locator('[aria-label*="Scheduled close"]');
+        await expect(badge).toBeVisible({ timeout: 8_000 });
+        await expect(badge).toContainText('#42');
+    });
+});

--- a/tcode/alpha_engine/ingestion/ibkr_order.py
+++ b/tcode/alpha_engine/ingestion/ibkr_order.py
@@ -596,6 +596,274 @@ def expiry_close(host: str, port: int, client_id: int, expiry_date: str = "") ->
         _disconnect(ib)
 
 
+def cancel_order_with_verify(host: str, port: int, client_id: int, order_id: int) -> dict:
+    """
+    Cancel an open IBKR order by ID and verify OCO sibling cancellation.
+
+    After issuing cancelOrder(), re-queries open_orders to confirm the parent
+    and any bracket siblings (TP/SL via OCO) have transitioned to Cancelled.
+
+    Returns:
+        {order_id, status, oca_cancelled: [sibling_ids], timestamp}
+    """
+    logger.info("cancel_order_with_verify: orderId=%d clientId=%d", order_id, client_id)
+
+    ib = _connect(host, port, client_id)
+    try:
+        ib.reqAllOpenOrders()
+        ib.sleep(1.0)
+
+        open_trades = ib.trades()
+        trade = next((t for t in open_trades if t.order.orderId == order_id), None)
+        if trade is None:
+            raise ValueError(f"Order {order_id} not found in open orders")
+
+        oca_group = trade.order.ocaGroup or ""
+        siblings_before = [
+            t.order.orderId
+            for t in open_trades
+            if t.order.ocaGroup == oca_group
+            and t.order.orderId != order_id
+            and oca_group
+        ]
+
+        ib.cancelOrder(trade.order)
+        ib.sleep(1.5)
+
+        # Independent verification: re-fetch open orders and confirm cancellation
+        ib.reqAllOpenOrders()
+        ib.sleep(1.0)
+
+        terminal = {"Cancelled", "Filled", "Inactive"}
+        post_trades = {t.order.orderId: t for t in ib.trades()}
+        target_status = (post_trades[order_id].orderStatus.status or "Unknown") if order_id in post_trades else "Cancelled"
+
+        oca_cancelled = []
+        for sid in siblings_before:
+            if sid in post_trades:
+                st = post_trades[sid].orderStatus.status or ""
+                if st in terminal:
+                    oca_cancelled.append(sid)
+            else:
+                # Not in open orders anymore → treated as cancelled
+                oca_cancelled.append(sid)
+
+        result = {
+            "order_id":      order_id,
+            "status":        target_status if target_status in terminal else "CancelPending",
+            "oca_cancelled": oca_cancelled,
+            "timestamp":     _now_iso(),
+        }
+        logger.info("cancel_order_with_verify result: %s", json.dumps(result))
+        return result
+    finally:
+        _disconnect(ib)
+
+
+def _is_market_hours() -> bool:
+    """
+    Return True if current UTC time falls within US regular session
+    (Mon–Fri 9:30–16:00 America/New_York).
+
+    Uses UTC offset approximation: ET is UTC-5 (EST) / UTC-4 (EDT).
+    We use pytz when available; otherwise fall back to a fixed UTC-4 offset
+    (EDT) which is correct for April–October, the primary trading season.
+    """
+    from datetime import datetime, timezone, timedelta
+
+    utc_now = datetime.now(timezone.utc)
+    # Weekday check: Mon=0 … Fri=4
+    try:
+        import zoneinfo
+        et = zoneinfo.ZoneInfo("America/New_York")
+        et_now = utc_now.astimezone(et)
+    except Exception:
+        # Fallback: EDT = UTC-4
+        et_now = utc_now.astimezone(timezone(timedelta(hours=-4)))
+
+    if et_now.weekday() >= 5:  # Saturday, Sunday
+        return False
+
+    t = et_now.hour * 60 + et_now.minute
+    return 9 * 60 + 30 <= t < 16 * 60  # 9:30 AM – 4:00 PM ET
+
+
+def _next_market_open_utc() -> "datetime":
+    """
+    Return the UTC datetime of the next regular-session open (9:30 AM ET Mon–Fri).
+    If we're before open today, returns today's open.
+    If past close or weekend, returns the next weekday's open.
+    """
+    from datetime import datetime, timezone, timedelta
+
+    utc_now = datetime.now(timezone.utc)
+    try:
+        import zoneinfo
+        et = zoneinfo.ZoneInfo("America/New_York")
+        et_now = utc_now.astimezone(et)
+    except Exception:
+        et_now = utc_now.astimezone(timezone(timedelta(hours=-4)))
+
+    # Candidate: today's open in ET
+    candidate = et_now.replace(hour=9, minute=30, second=0, microsecond=0)
+    t = et_now.hour * 60 + et_now.minute
+    is_weekday = et_now.weekday() < 5
+    before_open = t < 9 * 60 + 30
+
+    if is_weekday and before_open:
+        # Today's open hasn't happened yet
+        pass
+    else:
+        # Advance to next weekday
+        candidate += timedelta(days=1)
+        while candidate.weekday() >= 5:
+            candidate += timedelta(days=1)
+
+    return candidate.astimezone(timezone.utc)
+
+
+def close_position(
+    host: str,
+    port: int,
+    client_id: int,
+    symbol: str,
+    contract_type: str,
+    strike: float,
+    expiry: str,
+    quantity: int,
+) -> dict:
+    """
+    Close an open option position.
+
+    Auto-detects market hours:
+      - In-hours  → MKT DAY sell submitted immediately.
+      - Out-of-hours → schedule_close() with TIF=OPG for next session open.
+
+    Returns:
+        {order_id, status, scheduled_for, timestamp}
+        scheduled_for is null when the order executes immediately.
+    """
+    if _is_market_hours():
+        logger.info(
+            "close_position: market OPEN — submitting MKT DAY for %s %s %.2f %s x%d",
+            symbol, contract_type, strike, expiry, quantity,
+        )
+        return _close_position_mkt(host, port, client_id, symbol, contract_type, strike, expiry, quantity)
+    else:
+        logger.info(
+            "close_position: market CLOSED — scheduling OPG close for %s %s %.2f %s x%d",
+            symbol, contract_type, strike, expiry, quantity,
+        )
+        return schedule_close(host, port, client_id, symbol, contract_type, strike, expiry, quantity)
+
+
+def _close_position_mkt(
+    host: str,
+    port: int,
+    client_id: int,
+    symbol: str,
+    contract_type: str,
+    strike: float,
+    expiry: str,
+    quantity: int,
+) -> dict:
+    """Submit an immediate MKT DAY SELL to close the option position."""
+    from ib_insync import Option, MarketOrder
+
+    expiry_ib = _expiry_to_ib(expiry)
+    right = _right(contract_type)
+
+    logger.info(
+        "_close_position_mkt: SELL %dx %s %s %.2f %s MKT DAY clientId=%d",
+        quantity, symbol, contract_type, strike, expiry, client_id,
+    )
+
+    ib = _connect(host, port, client_id)
+    try:
+        contract = Option(symbol, expiry_ib, strike, right, "SMART")
+        qualified = ib.qualifyContracts(contract)
+        if not qualified:
+            raise ValueError(
+                f"Could not qualify contract: {symbol} {contract_type} "
+                f"strike={strike} expiry={expiry}"
+            )
+        contract = qualified[0]
+
+        order = MarketOrder("SELL", quantity, tif="DAY")
+        trade = ib.placeOrder(contract, order)
+        ib.sleep(ORDER_WAIT_SEC)
+
+        result = {
+            "order_id":      trade.order.orderId,
+            "status":        trade.orderStatus.status or "Submitted",
+            "scheduled_for": None,
+            "timestamp":     _now_iso(),
+        }
+        logger.info("[CLOSE-MKT] orderId=%d status=%s", result["order_id"], result["status"])
+        return result
+    finally:
+        _disconnect(ib)
+
+
+def schedule_close(
+    host: str,
+    port: int,
+    client_id: int,
+    symbol: str,
+    contract_type: str,
+    strike: float,
+    expiry: str,
+    quantity: int,
+) -> dict:
+    """
+    Schedule a position close for the next market open using TIF=OPG.
+
+    OPG (Opening) orders fill during the opening auction at 9:30 AM ET.
+    This is the correct mechanism for after-hours close requests.
+
+    Returns:
+        {order_id, status, scheduled_for (ISO8601 UTC), timestamp}
+    """
+    from ib_insync import Option, MarketOrder
+
+    expiry_ib = _expiry_to_ib(expiry)
+    right = _right(contract_type)
+    next_open = _next_market_open_utc()
+    next_open_iso = next_open.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    logger.info(
+        "schedule_close: OPG SELL %dx %s %s %.2f %s → %s clientId=%d",
+        quantity, symbol, contract_type, strike, expiry, next_open_iso, client_id,
+    )
+
+    ib = _connect(host, port, client_id)
+    try:
+        contract = Option(symbol, expiry_ib, strike, right, "SMART")
+        qualified = ib.qualifyContracts(contract)
+        if not qualified:
+            raise ValueError(
+                f"Could not qualify contract: {symbol} {contract_type} "
+                f"strike={strike} expiry={expiry}"
+            )
+        contract = qualified[0]
+
+        # OPG TIF = fills during opening auction only; cancelled if not filled at open
+        order = MarketOrder("SELL", quantity, tif="OPG")
+        trade = ib.placeOrder(contract, order)
+        ib.sleep(ORDER_WAIT_SEC)
+
+        result = {
+            "order_id":      trade.order.orderId,
+            "status":        trade.orderStatus.status or "PendingSubmit",
+            "scheduled_for": next_open_iso,
+            "timestamp":     _now_iso(),
+        }
+        logger.info("[SCHEDULE-CLOSE] orderId=%d scheduledFor=%s", result["order_id"], next_open_iso)
+        return result
+    finally:
+        _disconnect(ib)
+
+
 def global_cancel(host: str, port: int, client_id: int) -> dict:
     """
     Issue reqGlobalCancel() to clear all open orders at startup.
@@ -643,7 +911,11 @@ def main() -> None:
     )
     parser.add_argument(
         "command",
-        choices=["place", "cancel", "status", "open_orders", "expiry_close", "global_cancel"],
+        choices=[
+            "place", "cancel", "cancel_order", "status", "open_orders",
+            "expiry_close", "global_cancel",
+            "close_position", "schedule_close",
+        ],
     )
     parser.add_argument("--symbol",         default="TSLA")
     parser.add_argument("--contract",       default="CALL", help="CALL or PUT")
@@ -755,6 +1027,42 @@ def main() -> None:
             if args.order_id <= 0:
                 raise ValueError("--order-id is required and must be > 0")
             result = cancel_order(host, port, client_id, args.order_id)
+
+        elif args.command == "cancel_order":
+            # UI-facing cancel: verifies OCO sibling cancellation after the cancel
+            if args.order_id <= 0:
+                raise ValueError("--order-id is required and must be > 0")
+            result = cancel_order_with_verify(host, port, client_id, args.order_id)
+
+        elif args.command == "close_position":
+            # Close a position: MKT DAY if market open, OPG-scheduled if not
+            for field, val in [("--symbol", args.symbol), ("--strike", args.strike),
+                                ("--expiry", args.expiry), ("--quantity", args.quantity)]:
+                if not val:
+                    raise ValueError(f"{field} is required for close_position")
+            if args.strike <= 0:
+                raise ValueError("--strike must be > 0")
+            if args.quantity <= 0:
+                raise ValueError("--quantity must be > 0")
+            result = close_position(
+                host, port, client_id,
+                args.symbol, args.contract, args.strike, args.expiry, args.quantity,
+            )
+
+        elif args.command == "schedule_close":
+            # Explicitly schedule an OPG close for next market open
+            for field, val in [("--symbol", args.symbol), ("--strike", args.strike),
+                                ("--expiry", args.expiry), ("--quantity", args.quantity)]:
+                if not val:
+                    raise ValueError(f"{field} is required for schedule_close")
+            if args.strike <= 0:
+                raise ValueError("--strike must be > 0")
+            if args.quantity <= 0:
+                raise ValueError("--quantity must be > 0")
+            result = schedule_close(
+                host, port, client_id,
+                args.symbol, args.contract, args.strike, args.expiry, args.quantity,
+            )
 
         elif args.command == "status":
             if args.order_id <= 0:

--- a/tcode/alpha_engine/tests/test_cancel_close_roundtrip.py
+++ b/tcode/alpha_engine/tests/test_cancel_close_roundtrip.py
@@ -1,0 +1,188 @@
+"""
+Round-trip integration test: cancel pending order + close open position.
+
+Requires:
+  IBKR_GATEWAY_RUNNING=1  AND  EXECUTION_MODE=IBKR_PAPER
+  AND the execution engine running at localhost:2112
+
+Steps:
+  1. Place a far-OTM bracket order (limit price $0.01 — unlikely to fill)
+  2. Call POST /api/orders/cancel via HTTP
+  3. Independently verify via ibkr_order open_orders that order is Cancelled
+  4. Verify the scheduled-close path via the Python close_position function
+     (market-hours detection, OPG branch) — no real fill required for schedule step.
+
+@pytest.mark.integration
+"""
+import json
+import os
+import subprocess
+import sys
+import time
+import pytest
+import http.client
+
+# Resolve paths
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+_PYTHON    = os.path.join(_REPO_ROOT, "alpha_engine", "venv", "bin", "python")
+_AE_DIR    = os.path.join(_REPO_ROOT, "alpha_engine")
+
+_GATEWAY_RUNNING = os.getenv("IBKR_GATEWAY_RUNNING", "0") == "1"
+_ENGINE_HOST     = os.getenv("ENGINE_HOST", "localhost")
+_ENGINE_PORT     = int(os.getenv("ENGINE_PORT", "2112"))
+
+pytestmark = pytest.mark.skipif(
+    not _GATEWAY_RUNNING,
+    reason="IBKR_GATEWAY_RUNNING=1 required for round-trip test",
+)
+
+
+def _run_ibkr(command: str, **kwargs) -> dict:
+    args = [_PYTHON, "-m", "ingestion.ibkr_order"] + command.split()
+    result = subprocess.run(
+        args,
+        cwd=_AE_DIR,
+        capture_output=True, text=True, timeout=60,
+        env={**os.environ, "PYTHONPATH": _AE_DIR},
+    )
+    assert result.returncode == 0, f"ibkr_order failed: {result.stderr}"
+    return json.loads(result.stdout)
+
+
+def _api(method: str, path: str, body: dict | None = None) -> tuple[int, dict]:
+    conn = http.client.HTTPConnection(_ENGINE_HOST, _ENGINE_PORT, timeout=30)
+    headers = {"Content-Type": "application/json"}
+    payload = json.dumps(body).encode() if body else None
+    conn.request(method, path, payload, headers)
+    resp = conn.getresponse()
+    status = resp.status
+    data = json.loads(resp.read())
+    conn.close()
+    return status, data
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+FAR_OTM_STRIKE = 999.0   # Guaranteed far-OTM for TSLA
+FAR_OTM_EXPIRY = "2026-05-16"
+FAR_OTM_LIMIT  = 0.01    # $0.01 limit — very unlikely to fill
+
+
+def place_far_otm_bracket() -> dict:
+    """Place a far-OTM bracket order; returns the bracket result dict."""
+    return _run_ibkr(
+        f"place --symbol TSLA --contract CALL --strike {FAR_OTM_STRIKE} "
+        f"--expiry {FAR_OTM_EXPIRY} --action BUY --quantity 1 "
+        f"--limit-price {FAR_OTM_LIMIT} --take-profit 0.02 --stop-loss 0.005 "
+        f"--mode IBKR_PAPER --client-id 91"
+    )
+
+
+def get_open_orders() -> list:
+    return _run_ibkr("open_orders --mode IBKR_PAPER --client-id 92").get("orders", [])
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+class TestCancelRoundtrip:
+    def test_cancel_via_api_reflects_in_ibkr(self):
+        """
+        Place far-OTM bracket → cancel via /api/orders/cancel →
+        verify ib.openOrders shows Cancelled status.
+        """
+        # 1. Place bracket
+        bracket = place_far_otm_bracket()
+        parent_id = bracket["parent_order_id"]
+        assert parent_id > 0, f"Bracket placement returned no parent ID: {bracket}"
+
+        time.sleep(2)
+
+        # 2. Cancel via engine API
+        status, data = _api("POST", "/api/orders/cancel", {"order_id": parent_id})
+        assert status == 200, f"/api/orders/cancel returned {status}: {data}"
+        assert "error" not in data or not data["error"], f"Cancel error: {data}"
+
+        time.sleep(2)
+
+        # 3. Verify independently: order should be Cancelled in IBKR
+        orders_after = get_open_orders()
+        ids_by_status = {o["orderId"]: o["status"] for o in orders_after}
+
+        # Parent should be absent or Cancelled
+        parent_status = ids_by_status.get(parent_id, "Cancelled")
+        assert parent_status in ("Cancelled", "Inactive"), (
+            f"Parent order {parent_id} still active: {parent_status}"
+        )
+
+        # OCO siblings should also be absent or Cancelled
+        tp_id = bracket["take_profit_order_id"]
+        sl_id = bracket["stop_loss_order_id"]
+        for sid, label in [(tp_id, "TP"), (sl_id, "SL")]:
+            sibling_status = ids_by_status.get(sid, "Cancelled")
+            assert sibling_status in ("Cancelled", "Inactive"), (
+                f"{label} leg {sid} still active after parent cancel: {sibling_status}"
+            )
+
+
+class TestClosePositionSchedule:
+    def test_close_position_returns_scheduled_for_when_market_closed(self):
+        """
+        When market is closed, close_position auto-detects and calls schedule_close
+        which returns a non-None scheduled_for field.
+
+        This test mocks market hours by calling the Python function directly
+        with the knowledge that after 16:00 ET or on weekends it will schedule.
+        """
+        from ingestion.ibkr_order import _is_market_hours, _next_market_open_utc
+        from datetime import timezone
+
+        # This assertion tests the helper logic, not the broker
+        next_open = _next_market_open_utc()
+        assert next_open.tzinfo is not None
+        assert next_open.tzinfo == timezone.utc or str(next_open.tzinfo) == "UTC"
+
+        # next_open must be in the future
+        from datetime import datetime
+        assert next_open > datetime.now(timezone.utc), "Next market open must be in the future"
+
+        # next_open must be a weekday
+        try:
+            import zoneinfo
+            et = zoneinfo.ZoneInfo("America/New_York")
+            nxt_et = next_open.astimezone(et)
+        except Exception:
+            from datetime import timedelta
+            nxt_et = next_open.astimezone(timezone(timedelta(hours=-4)))
+
+        assert nxt_et.weekday() < 5, f"Next open is a weekend: {nxt_et}"
+        assert (nxt_et.hour, nxt_et.minute) == (9, 30), f"Open time not 9:30 ET: {nxt_et}"
+
+    def test_close_via_api_returns_order_id(self):
+        """
+        Call POST /api/positions/close with a synthetic position key.
+        Requires a real IBKR position to be open.
+        Skip gracefully if no position exists.
+        """
+        # Get current positions from engine
+        status, positions = _api("GET", "/api/positions")
+        if status != 200 or not positions:
+            pytest.skip("No open IBKR positions to close")
+
+        # Pick the first option position
+        pos_list = positions if isinstance(positions, list) else []
+        opt_positions = [p for p in pos_list if p.get("sec_type") == "OPT"]
+        if not opt_positions:
+            pytest.skip("No OPT positions available")
+
+        pos = opt_positions[0]
+        contract_key = f"{pos['ticker']}_{pos['option_type']}_{pos['expiration']}_{pos['strike']}"
+
+        close_status, close_data = _api("POST", "/api/positions/close", {
+            "contract_key": contract_key,
+            "quantity": pos["qty"],
+            "market_open_if_closed": True,
+        })
+
+        assert close_status == 200, f"/api/positions/close returned {close_status}: {close_data}"
+        assert "error" not in close_data or not close_data["error"]
+        assert close_data.get("order_id", 0) > 0, f"No order_id in response: {close_data}"

--- a/tcode/alpha_engine/tests/test_ibkr_order_close.py
+++ b/tcode/alpha_engine/tests/test_ibkr_order_close.py
@@ -1,0 +1,200 @@
+"""
+Unit tests for ibkr_order.py Phase 12 subcommands:
+  cancel_order_with_verify, close_position, schedule_close
+
+All tests mock ib_insync so no live gateway is required.
+"""
+import json
+import sys
+import os
+import unittest
+from unittest.mock import MagicMock, patch, PropertyMock
+from datetime import datetime, timezone, timedelta
+
+# Resolve alpha_engine on sys.path
+_HERE = os.path.dirname(__file__)
+_AE = os.path.abspath(os.path.join(_HERE, ".."))
+if _AE not in sys.path:
+    sys.path.insert(0, _AE)
+
+from ingestion.ibkr_order import (
+    cancel_order_with_verify,
+    close_position,
+    schedule_close,
+    _is_market_hours,
+    _next_market_open_utc,
+)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _make_trade(order_id: int, status: str, oca_group: str = "", parent_id: int = 0):
+    trade = MagicMock()
+    trade.order.orderId = order_id
+    trade.order.ocaGroup = oca_group
+    trade.order.parentId = parent_id
+    trade.order.orderType = "LMT"
+    trade.orderStatus.status = status
+    trade.orderStatus.filled = 0
+    trade.orderStatus.avgFillPrice = 0
+    trade.contract.secType = "OPT"
+    trade.contract.symbol = "TSLA"
+    trade.contract.strike = "365"
+    trade.contract.lastTradeDateOrContractMonth = "20260413"
+    trade.contract.right = "C"
+    trade.contract.conId = 999
+    return trade
+
+
+def _make_ib(trades_before, trades_after=None):
+    """Return a mock IB instance pre-loaded with trades."""
+    ib = MagicMock()
+    ib.trades.side_effect = [trades_before, trades_after or trades_before]
+    ib.cancelOrder.return_value = None
+
+    # qualify returns a single mock contract
+    mock_contract = MagicMock()
+    mock_contract.conId = 999
+    ib.qualifyContracts.return_value = [mock_contract]
+
+    # placeOrder returns a mock trade
+    placed = _make_trade(42, "PendingSubmit")
+    ib.placeOrder.return_value = placed
+    return ib
+
+
+# ── cancel_order_with_verify ──────────────────────────────────────────────────
+
+class TestCancelOrderWithVerify(unittest.TestCase):
+
+    @patch("ingestion.ibkr_order._disconnect")
+    @patch("ingestion.ibkr_order._connect")
+    def test_cancel_single_order(self, mock_connect, mock_disconnect):
+        trade = _make_trade(101, "Cancelled")
+        ib = _make_ib([trade], [trade])
+        mock_connect.return_value = ib
+
+        result = cancel_order_with_verify("127.0.0.1", 4002, 3, 101)
+
+        self.assertEqual(result["order_id"], 101)
+        self.assertIn(result["status"], ("Cancelled", "CancelPending"))
+        self.assertEqual(result["oca_cancelled"], [])
+        ib.cancelOrder.assert_called_once()
+
+    @patch("ingestion.ibkr_order._disconnect")
+    @patch("ingestion.ibkr_order._connect")
+    def test_cancel_bracket_parent_detects_oca_siblings(self, mock_connect, mock_disconnect):
+        parent = _make_trade(200, "Cancelled", oca_group="GRP1")
+        tp     = _make_trade(201, "Cancelled", oca_group="GRP1", parent_id=200)
+        sl     = _make_trade(202, "Cancelled", oca_group="GRP1", parent_id=200)
+
+        # Before: all three active; after cancel: all show Cancelled
+        before = [parent, tp, sl]
+        after  = [
+            _make_trade(200, "Cancelled", oca_group="GRP1"),
+            _make_trade(201, "Cancelled", oca_group="GRP1", parent_id=200),
+            _make_trade(202, "Cancelled", oca_group="GRP1", parent_id=200),
+        ]
+        ib = MagicMock()
+        ib.trades.side_effect = [before, after]
+        ib.cancelOrder.return_value = None
+        mock_connect.return_value = ib
+
+        result = cancel_order_with_verify("127.0.0.1", 4002, 3, 200)
+
+        self.assertEqual(result["order_id"], 200)
+        self.assertIn(201, result["oca_cancelled"])
+        self.assertIn(202, result["oca_cancelled"])
+
+    @patch("ingestion.ibkr_order._disconnect")
+    @patch("ingestion.ibkr_order._connect")
+    def test_raises_if_order_not_found(self, mock_connect, mock_disconnect):
+        ib = MagicMock()
+        ib.trades.return_value = []
+        mock_connect.return_value = ib
+
+        with self.assertRaises(ValueError, msg="Order 999 not found in open orders"):
+            cancel_order_with_verify("127.0.0.1", 4002, 3, 999)
+
+
+# ── close_position ────────────────────────────────────────────────────────────
+
+class TestClosePosition(unittest.TestCase):
+
+    @patch("ingestion.ibkr_order._is_market_hours", return_value=True)
+    @patch("ingestion.ibkr_order._close_position_mkt")
+    def test_delegates_to_mkt_when_market_open(self, mock_mkt, mock_hours):
+        mock_mkt.return_value = {"order_id": 55, "status": "Submitted", "scheduled_for": None, "timestamp": "T"}
+        result = close_position("127.0.0.1", 4002, 3, "TSLA", "CALL", 365.0, "2026-04-13", 10)
+        mock_mkt.assert_called_once()
+        self.assertIsNone(result["scheduled_for"])
+
+    @patch("ingestion.ibkr_order._is_market_hours", return_value=False)
+    @patch("ingestion.ibkr_order.schedule_close")
+    def test_delegates_to_schedule_when_market_closed(self, mock_sched, mock_hours):
+        mock_sched.return_value = {
+            "order_id": 77, "status": "PendingSubmit",
+            "scheduled_for": "2026-04-14T13:30:00Z", "timestamp": "T",
+        }
+        result = close_position("127.0.0.1", 4002, 3, "TSLA", "CALL", 365.0, "2026-04-13", 10)
+        mock_sched.assert_called_once()
+        self.assertEqual(result["scheduled_for"], "2026-04-14T13:30:00Z")
+
+
+# ── schedule_close ────────────────────────────────────────────────────────────
+
+class TestScheduleClose(unittest.TestCase):
+
+    @patch("ingestion.ibkr_order._disconnect")
+    @patch("ingestion.ibkr_order._connect")
+    @patch("ingestion.ibkr_order._next_market_open_utc")
+    def test_schedule_close_submits_opg_order(self, mock_next_open, mock_connect, mock_disconnect):
+        from datetime import datetime, timezone
+        next_open = datetime(2026, 4, 14, 13, 30, 0, tzinfo=timezone.utc)
+        mock_next_open.return_value = next_open
+
+        placed = _make_trade(99, "PendingSubmit")
+        ib = MagicMock()
+        ib.qualifyContracts.return_value = [MagicMock(conId=888)]
+        ib.placeOrder.return_value = placed
+        mock_connect.return_value = ib
+
+        result = schedule_close("127.0.0.1", 4002, 3, "TSLA", "CALL", 365.0, "2026-04-13", 10)
+
+        self.assertEqual(result["order_id"], 99)
+        self.assertEqual(result["scheduled_for"], "2026-04-14T13:30:00Z")
+        # Verify TIF=OPG was used
+        call_args = ib.placeOrder.call_args
+        order_arg = call_args[0][1]
+        self.assertEqual(order_arg.tif, "OPG")
+        self.assertEqual(order_arg.action, "SELL")
+
+
+# ── market hours helpers ──────────────────────────────────────────────────────
+
+class TestMarketHoursHelpers(unittest.TestCase):
+
+    def test_next_market_open_utc_returns_future_datetime(self):
+        nxt = _next_market_open_utc()
+        now = datetime.now(timezone.utc)
+        self.assertGreater(nxt, now)
+
+    def test_next_market_open_utc_is_weekday(self):
+        nxt = _next_market_open_utc()
+        # Convert to ET for weekday check
+        try:
+            import zoneinfo
+            et = zoneinfo.ZoneInfo("America/New_York")
+            nxt_et = nxt.astimezone(et)
+        except Exception:
+            nxt_et = nxt.astimezone(timezone(timedelta(hours=-4)))
+        self.assertLess(nxt_et.weekday(), 5, "Next open must not be a weekend")
+        self.assertEqual((nxt_et.hour, nxt_et.minute), (9, 30))
+
+    def test_is_market_hours_returns_bool(self):
+        result = _is_market_hours()
+        self.assertIsInstance(result, bool)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tcode/execution_engine/api.go
+++ b/tcode/execution_engine/api.go
@@ -1733,6 +1733,144 @@ func (h *ConfigHandler) ServeOrdersPending(w http.ResponseWriter, r *http.Reques
 	})
 }
 
+// auditLog emits a structured audit record to the process log.
+// Every cancel/close action is recorded with timestamp, endpoint, request
+// body, mode, and result so the dashboard event feed can replay it.
+func auditLog(endpoint, mode string, reqBody, result interface{}) {
+	reqJSON, _ := json.Marshal(reqBody)
+	resJSON, _ := json.Marshal(result)
+	log.Printf("[AUDIT] endpoint=%s mode=%s request=%s response=%s",
+		endpoint, mode, reqJSON, resJSON)
+}
+
+// ServeOrdersCancel handles POST /api/orders/cancel.
+//
+// Body: {"order_id": N}
+// Returns: CancelOrderResult JSON from ibkr_order cancel_order subprocess.
+//
+// Rejects with 400 if mode is SIMULATION, order_id is missing/zero, or the
+// request method is not POST.  Logs an [AUDIT] entry for every attempt.
+func (h *ConfigHandler) ServeOrdersCancel(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	if r.Method != "POST" {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+	if ActiveExecutionMode == ModeSimulation {
+		http.Error(w, `{"error":"SIMULATION mode — cancel requires a real broker"}`, http.StatusBadRequest)
+		return
+	}
+
+	var body struct {
+		OrderID int `json:"order_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, `{"error":"invalid JSON body"}`, http.StatusBadRequest)
+		return
+	}
+	if body.OrderID <= 0 {
+		http.Error(w, `{"error":"order_id is required and must be > 0"}`, http.StatusBadRequest)
+		return
+	}
+
+	result, err := CancelOrderUI(body.OrderID)
+	if err != nil {
+		errPayload := map[string]string{"error": err.Error()}
+		auditLog("/api/orders/cancel", string(ActiveExecutionMode), body, errPayload)
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(errPayload)
+		return
+	}
+
+	// Remove from internal pending cap tracker so rank state is consistent
+	removePendingOrder(body.OrderID)
+
+	auditLog("/api/orders/cancel", string(ActiveExecutionMode), body, result)
+	json.NewEncoder(w).Encode(result)
+}
+
+// parseContractKey splits "TSLA_CALL_2026-04-13_365" into its four components.
+// Expected format: {SYMBOL}_{CONTRACT_TYPE}_{EXPIRY}_{STRIKE}
+// e.g. "TSLA_CALL_2026-04-13_365.0"
+func parseContractKey(key string) (symbol, contractType, expiry string, strike float64, err error) {
+	// Use SplitN 4 to handle symbols that might embed underscores (future-proof)
+	parts := strings.SplitN(key, "_", 4)
+	if len(parts) != 4 {
+		err = fmt.Errorf("contract_key must be SYMBOL_TYPE_EXPIRY_STRIKE, got %q", key)
+		return
+	}
+	symbol       = parts[0]
+	contractType = parts[1]
+	expiry       = parts[2]
+	strike, err  = strconv.ParseFloat(parts[3], 64)
+	if err != nil {
+		err = fmt.Errorf("invalid strike in contract_key %q: %w", key, err)
+	}
+	return
+}
+
+// ServePositionsClose handles POST /api/positions/close.
+//
+// Body: {"contract_key": "TSLA_CALL_2026-04-13_365", "quantity": 10, "market_open_if_closed": true}
+// Returns: ClosePositionResult JSON from ibkr_order close_position subprocess.
+//
+// When market_open_if_closed is true (default), close_position auto-schedules
+// an OPG order if the market is currently closed.  The response includes a
+// non-empty scheduled_for field in that case.
+func (h *ConfigHandler) ServePositionsClose(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	if r.Method != "POST" {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+	if ActiveExecutionMode == ModeSimulation {
+		http.Error(w, `{"error":"SIMULATION mode — close requires a real broker"}`, http.StatusBadRequest)
+		return
+	}
+
+	var body struct {
+		ContractKey        string `json:"contract_key"`
+		Quantity           int    `json:"quantity"`
+		MarketOpenIfClosed bool   `json:"market_open_if_closed"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, `{"error":"invalid JSON body"}`, http.StatusBadRequest)
+		return
+	}
+	if body.ContractKey == "" {
+		http.Error(w, `{"error":"contract_key is required"}`, http.StatusBadRequest)
+		return
+	}
+	if body.Quantity <= 0 {
+		http.Error(w, `{"error":"quantity must be > 0"}`, http.StatusBadRequest)
+		return
+	}
+
+	symbol, contractType, expiry, strike, err := parseContractKey(body.ContractKey)
+	if err != nil {
+		errPayload := map[string]string{"error": err.Error()}
+		auditLog("/api/positions/close", string(ActiveExecutionMode), body, errPayload)
+		http.Error(w, `{"error":"`+err.Error()+`"}`, http.StatusBadRequest)
+		return
+	}
+
+	result, err := ClosePositionIBKR(symbol, contractType, strike, expiry, body.Quantity)
+	if err != nil {
+		errPayload := map[string]string{"error": err.Error()}
+		auditLog("/api/positions/close", string(ActiveExecutionMode), body, errPayload)
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(errPayload)
+		return
+	}
+
+	auditLog("/api/positions/close", string(ActiveExecutionMode), body, result)
+	json.NewEncoder(w).Encode(result)
+}
+
 // ServeCapEvents returns the last 10 [REPLACE] / [REJECT-CAP] events for the UI feed.
 func (h *ConfigHandler) ServeCapEvents(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")

--- a/tcode/execution_engine/ibkr_client.go
+++ b/tcode/execution_engine/ibkr_client.go
@@ -272,6 +272,90 @@ func ExpiryCloseIBKROrders(expiryDate string) {
 	log.Printf("[EXPIRY-CLOSE] closed %d expiring positions for %s", result.ClosedCount, expiryDate)
 }
 
+// CancelOrderResult is the JSON payload returned by ibkr_order.py cancel_order.
+type CancelOrderResult struct {
+	OrderID      int    `json:"order_id"`
+	Status       string `json:"status"`
+	OcaCancelled []int  `json:"oca_cancelled"` // sibling IDs cancelled via OCO
+	Timestamp    string `json:"timestamp"`
+	Error        string `json:"error,omitempty"`
+}
+
+// CancelOrderUI shells out to ibkr_order cancel_order — the UI-facing cancel path.
+// Unlike the engine-internal CancelIBKROrder, it re-queries open_orders afterward
+// to confirm bracket OCO siblings were also cancelled, and returns the verification result.
+func CancelOrderUI(orderID int) (*CancelOrderResult, error) {
+	clientID := AllocateClientID()
+	args := []string{
+		"-m", "ingestion.ibkr_order", "cancel_order",
+		"--order-id", fmt.Sprintf("%d", orderID),
+		"--mode",     string(ActiveExecutionMode),
+		"--client-id", fmt.Sprintf("%d", clientID),
+	}
+
+	cmd := exec.Command(pythonBin(), args...)
+	cmd.Dir = "./alpha_engine"
+	cmd.Env = os.Environ()
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("ibkr_order cancel_order failed: %w (stderr=%s)", err, stderrString(err))
+	}
+
+	var result CancelOrderResult
+	if err := json.Unmarshal(out, &result); err != nil {
+		return nil, fmt.Errorf("ibkr_order cancel_order JSON: %w (raw=%s)", err, string(out))
+	}
+	if result.Error != "" {
+		return nil, fmt.Errorf("ibkr_order cancel_order: %s", result.Error)
+	}
+	return &result, nil
+}
+
+// ClosePositionResult is the JSON payload returned by ibkr_order.py close_position.
+type ClosePositionResult struct {
+	OrderID      int    `json:"order_id"`
+	Status       string `json:"status"`
+	ScheduledFor string `json:"scheduled_for"` // empty string → immediate; ISO8601 UTC → OPG-scheduled
+	Timestamp    string `json:"timestamp"`
+	Error        string `json:"error,omitempty"`
+}
+
+// ClosePositionIBKR shells out to ibkr_order close_position.
+// The Python subprocess auto-detects market hours and either submits MKT DAY
+// or schedules a TIF=OPG order for the next session open.
+func ClosePositionIBKR(symbol, contractType string, strike float64, expiry string, qty int) (*ClosePositionResult, error) {
+	clientID := AllocateClientID()
+	args := []string{
+		"-m", "ingestion.ibkr_order", "close_position",
+		"--symbol",   symbol,
+		"--contract", contractType,
+		"--strike",   fmt.Sprintf("%g", strike),
+		"--expiry",   expiry,
+		"--quantity", fmt.Sprintf("%d", qty),
+		"--mode",     string(ActiveExecutionMode),
+		"--client-id", fmt.Sprintf("%d", clientID),
+	}
+
+	cmd := exec.Command(pythonBin(), args...)
+	cmd.Dir = "./alpha_engine"
+	cmd.Env = os.Environ()
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("ibkr_order close_position failed: %w (stderr=%s)", err, stderrString(err))
+	}
+
+	var result ClosePositionResult
+	if err := json.Unmarshal(out, &result); err != nil {
+		return nil, fmt.Errorf("ibkr_order close_position JSON: %w (raw=%s)", err, string(out))
+	}
+	if result.Error != "" {
+		return nil, fmt.Errorf("ibkr_order close_position: %s", result.Error)
+	}
+	return &result, nil
+}
+
 // OpenIBKROrders returns the list of currently open orders from IBKR.
 // Used by the reconciler to sync internal state with the broker.
 func OpenIBKROrders() ([]OrderResult, error) {

--- a/tcode/execution_engine/main.go
+++ b/tcode/execution_engine/main.go
@@ -222,7 +222,9 @@ func main() {
 	mux.HandleFunc("/api/losses", configHandler.ServeLossSummary)
 	mux.HandleFunc("/api/fills/tag", configHandler.ServeTagTrade)
 	mux.HandleFunc("/api/orders/pending", configHandler.ServeOrdersPending)
+	mux.HandleFunc("/api/orders/cancel", configHandler.ServeOrdersCancel)
 	mux.HandleFunc("/api/orders/cap-events", configHandler.ServeCapEvents)
+	mux.HandleFunc("/api/positions/close", configHandler.ServePositionsClose)
 	mux.HandleFunc("/api/config/notional", configHandler.ServeNotionalConfig)
 
 	// Live Reload WebSocket (Task: Auto-Refresh)

--- a/tcode/execution_engine/orders_cancel_close_test.go
+++ b/tcode/execution_engine/orders_cancel_close_test.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ── parseContractKey ──────────────────────────────────────────────────────────
+
+func TestParseContractKey_Valid(t *testing.T) {
+	sym, ct, exp, strike, err := parseContractKey("TSLA_CALL_2026-04-13_365")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sym != "TSLA" || ct != "CALL" || exp != "2026-04-13" || strike != 365.0 {
+		t.Fatalf("parsed wrong: sym=%q ct=%q exp=%q strike=%f", sym, ct, exp, strike)
+	}
+}
+
+func TestParseContractKey_WithDecimalStrike(t *testing.T) {
+	_, _, _, strike, err := parseContractKey("TSLA_PUT_2026-05-16_362.5")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strike != 362.5 {
+		t.Fatalf("expected 362.5 got %f", strike)
+	}
+}
+
+func TestParseContractKey_TooFewParts(t *testing.T) {
+	_, _, _, _, err := parseContractKey("TSLA_CALL_2026-04-13")
+	if err == nil {
+		t.Fatal("expected error for malformed key")
+	}
+}
+
+func TestParseContractKey_BadStrike(t *testing.T) {
+	_, _, _, _, err := parseContractKey("TSLA_CALL_2026-04-13_notanumber")
+	if err == nil {
+		t.Fatal("expected error for non-numeric strike")
+	}
+}
+
+// ── /api/orders/cancel ────────────────────────────────────────────────────────
+
+// makeTestHandler builds a ConfigHandler suitable for unit tests (no live deps).
+func makeTestHandler() *ConfigHandler {
+	return &ConfigHandler{
+		Portfolio: NewPaperPortfolio(100_000),
+	}
+}
+
+func TestServeOrdersCancel_MethodNotAllowed(t *testing.T) {
+	h := makeTestHandler()
+	req := httptest.NewRequest("GET", "/api/orders/cancel", nil)
+	w := httptest.NewRecorder()
+	h.ServeOrdersCancel(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405 got %d", w.Code)
+	}
+}
+
+func TestServeOrdersCancel_SimulationMode(t *testing.T) {
+	orig := ActiveExecutionMode
+	ActiveExecutionMode = ModeSimulation
+	defer func() { ActiveExecutionMode = orig }()
+
+	h := makeTestHandler()
+	body := `{"order_id": 42}`
+	req := httptest.NewRequest("POST", "/api/orders/cancel", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeOrdersCancel(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 in SIMULATION mode, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "SIMULATION") {
+		t.Fatalf("expected SIMULATION error message, got: %s", w.Body.String())
+	}
+}
+
+func TestServeOrdersCancel_MissingOrderID(t *testing.T) {
+	orig := ActiveExecutionMode
+	ActiveExecutionMode = ModeIBKRPaper
+	defer func() { ActiveExecutionMode = orig }()
+
+	h := makeTestHandler()
+	body := `{"order_id": 0}`
+	req := httptest.NewRequest("POST", "/api/orders/cancel", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeOrdersCancel(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for zero order_id, got %d", w.Code)
+	}
+}
+
+func TestServeOrdersCancel_InvalidJSON(t *testing.T) {
+	orig := ActiveExecutionMode
+	ActiveExecutionMode = ModeIBKRPaper
+	defer func() { ActiveExecutionMode = orig }()
+
+	h := makeTestHandler()
+	req := httptest.NewRequest("POST", "/api/orders/cancel", strings.NewReader("not-json"))
+	w := httptest.NewRecorder()
+	h.ServeOrdersCancel(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid JSON, got %d", w.Code)
+	}
+}
+
+// ── /api/positions/close ──────────────────────────────────────────────────────
+
+func TestServePositionsClose_MethodNotAllowed(t *testing.T) {
+	h := makeTestHandler()
+	req := httptest.NewRequest("GET", "/api/positions/close", nil)
+	w := httptest.NewRecorder()
+	h.ServePositionsClose(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405 got %d", w.Code)
+	}
+}
+
+func TestServePositionsClose_SimulationMode(t *testing.T) {
+	orig := ActiveExecutionMode
+	ActiveExecutionMode = ModeSimulation
+	defer func() { ActiveExecutionMode = orig }()
+
+	h := makeTestHandler()
+	body := `{"contract_key":"TSLA_CALL_2026-04-13_365","quantity":10,"market_open_if_closed":true}`
+	req := httptest.NewRequest("POST", "/api/positions/close", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServePositionsClose(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 in SIMULATION mode, got %d", w.Code)
+	}
+}
+
+func TestServePositionsClose_MissingContractKey(t *testing.T) {
+	orig := ActiveExecutionMode
+	ActiveExecutionMode = ModeIBKRPaper
+	defer func() { ActiveExecutionMode = orig }()
+
+	h := makeTestHandler()
+	body := `{"contract_key":"","quantity":10}`
+	req := httptest.NewRequest("POST", "/api/positions/close", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServePositionsClose(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty contract_key, got %d", w.Code)
+	}
+}
+
+func TestServePositionsClose_ZeroQuantity(t *testing.T) {
+	orig := ActiveExecutionMode
+	ActiveExecutionMode = ModeIBKRPaper
+	defer func() { ActiveExecutionMode = orig }()
+
+	h := makeTestHandler()
+	body := `{"contract_key":"TSLA_CALL_2026-04-13_365","quantity":0}`
+	req := httptest.NewRequest("POST", "/api/positions/close", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServePositionsClose(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for zero quantity, got %d", w.Code)
+	}
+}
+
+func TestServePositionsClose_MalformedContractKey(t *testing.T) {
+	orig := ActiveExecutionMode
+	ActiveExecutionMode = ModeIBKRPaper
+	defer func() { ActiveExecutionMode = orig }()
+
+	h := makeTestHandler()
+	body := `{"contract_key":"TSLA_CALL_notvalid","quantity":5}`
+	req := httptest.NewRequest("POST", "/api/positions/close", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServePositionsClose(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for malformed contract_key, got %d", w.Code)
+	}
+}
+
+// ── auditLog marshalling ──────────────────────────────────────────────────────
+
+func TestAuditLog_DoesNotPanic(t *testing.T) {
+	// Just confirm auditLog doesn't panic for various input types
+	auditLog("/api/orders/cancel", "IBKR_PAPER", map[string]int{"order_id": 42}, map[string]string{"status": "Cancelled"})
+	auditLog("/api/positions/close", "IBKR_PAPER", nil, nil)
+
+	// Unencodable input should not panic (json.Marshal silences errors)
+	type cyclicSafe struct{ Val int }
+	auditLog("/test", "PAPER", cyclicSafe{1}, cyclicSafe{2})
+}
+
+// ── JSON response shape sanity ────────────────────────────────────────────────
+
+func TestCancelOrderResult_JSONRoundtrip(t *testing.T) {
+	r := CancelOrderResult{
+		OrderID:      101,
+		Status:       "Cancelled",
+		OcaCancelled: []int{102, 103},
+		Timestamp:    "2026-04-13T14:00:00Z",
+	}
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out CancelOrderResult
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.OrderID != 101 || len(out.OcaCancelled) != 2 {
+		t.Fatalf("roundtrip mismatch: %+v", out)
+	}
+}
+
+func TestClosePositionResult_JSONRoundtrip(t *testing.T) {
+	r := ClosePositionResult{
+		OrderID:      77,
+		Status:       "PendingSubmit",
+		ScheduledFor: "2026-04-14T13:30:00Z",
+		Timestamp:    "2026-04-13T20:00:00Z",
+	}
+	b, _ := json.Marshal(r)
+
+	// POST body simulation: wrap in httptest
+	req := httptest.NewRequest("POST", "/api/positions/close",
+		bytes.NewReader([]byte(`{"contract_key":"TSLA_CALL_2026-04-13_365","quantity":5}`)),
+	)
+	_ = req // Just confirm the struct fields match the expected JSON shape
+
+	var out ClosePositionResult
+	json.Unmarshal(b, &out)
+	if out.ScheduledFor != "2026-04-14T13:30:00Z" {
+		t.Fatalf("scheduled_for roundtrip failed: %q", out.ScheduledFor)
+	}
+}


### PR DESCRIPTION
Phase 12 ships the trade-management UI: per-row cancel for pending orders, per-row close for open positions, market-hours-aware scheduling (TIF=OPG queue when market closed), and audit logging.

## Commits
- feat(ibkr): cancel_order / close_position / schedule_close subcommands
- feat(api): POST /api/orders/cancel and /api/positions/close with audit logging
- feat(ui): cancel button + confirm modal on Pending Orders rows
- test: cancel/close unit + api + Playwright + roundtrip coverage

## Test plan
- [x] Python unit tests pass; roundtrip skipped without live gateway
- [x] Go unit tests pass
- [x] Playwright UX gate green
- [ ] Manual: live IBKR paper roundtrip