### PR TITLE
Stabilization Phase 13.5 — data-source repairs + IBKR contract qualification

### DIFF
--- a/tcode/alpha_control_center/src/lib/term_glossary.ts
+++ b/tcode/alpha_control_center/src/lib/term_glossary.ts
@@ -707,6 +707,102 @@ Only strikes passing the minimum OI filter enter the signal pipeline.`,
     phase_note: "Added in Phase 14 — values not yet shown in the UI.",
     related: ["SPREAD_TIGHTNESS", "DELTA_FIT"],
   },
+
+  // ── Phase 13.5: Data-source repair terms ─────────────────────────────────
+
+  DXY_SOURCE: {
+    term: "DXY_SOURCE",
+    display: "DXY (US Dollar Index)",
+    short: "US Dollar Index — measures dollar strength vs 6 major currencies. Rising DXY = risk-off signal for equities.",
+    long: `**DXY (US Dollar Index)** tracks the value of the US dollar against a basket of 6 major currencies (EUR 57.6%, JPY 13.6%, GBP 11.9%, CAD 9.1%, SEK 4.2%, CHF 3.6%).
+
+**Source chain (Phase 13.5):**
+- **Primary**: DX-Y.NYB — ICE US Dollar Index futures continuous contract, intraday available via yfinance.
+- **Proxy fallback**: UUP — Invesco DB US Dollar Index Bullish ETF. ~1:1 directional correlation with DXY.
+- **Unavailable**: If both fail, DXY is omitted from the composite confidence adjustment.
+
+The legacy \`^DXY\` ticker was delisted from yfinance data feeds as of early 2026.`,
+    source: "DX-Y.NYB (ICE futures) via yfinance — primary; UUP ETF as proxy fallback",
+    trading_impact: "DXY move >0.5% adds ±0.20 to pre-market composite confidence. Rising DXY dampens bullish equity bias.",
+    related: ["UUP_PROXY"],
+    phase_note: "Updated in Phase 13.5 — ^DXY delisted; using DX-Y.NYB primary + UUP proxy.",
+  },
+
+  UUP_PROXY: {
+    term: "UUP_PROXY",
+    display: "UUP (DXY Proxy)",
+    short: "Invesco DB US Dollar Index Bullish ETF — used as a DXY proxy when the primary DX-Y.NYB source fails.",
+    long: `**UUP** (Invesco DB US Dollar Index Bullish Fund) is an ETF that tracks the Deutsche Bank Long US Dollar Futures index, which closely follows DXY composition.
+
+Used as a **proxy** for DXY when the primary DX-Y.NYB futures contract is unavailable. The directional correlation is ~1:1, though the absolute price level is different (~28 vs DXY ~104).
+
+When UUP is shown as the source, the system is using UUP % change as a stand-in for DXY % change. The confidence adjustment logic (>0.5% move = ±0.20 confidence) applies identically.
+
+**Tradeoff**: UUP has slightly less granularity than the ICE futures contract and may lag by a few minutes during pre-market hours.`,
+    source: "UUP ETF via yfinance — fallback when DX-Y.NYB returns empty data",
+    trading_impact: "Same as DXY_SOURCE: >0.5% move adjusts pre-market confidence ±0.20.",
+    related: ["DXY_SOURCE"],
+    phase_note: "Added in Phase 13.5 as DXY fallback.",
+  },
+
+  SOURCE_DEGRADED: {
+    term: "SOURCE_DEGRADED",
+    display: "Feed Degraded",
+    short: "A data source failed 3+ times consecutively and is in circuit-breaker mode — retrying after a 10-minute cooldown.",
+    long: `**Feed Degraded** means a data source has exceeded the retry threshold and the circuit breaker has opened.
+
+**Circuit breaker behavior (Phase 13.5):**
+- 3 attempts with exponential backoff (1s, 4s, 16s)
+- After 3 consecutive failures, the source is marked degraded for 10 minutes
+- During cooldown, no requests are sent (prevents hammering a down endpoint)
+- After cooldown, one probe is allowed; success resets the counter
+
+**While degraded:**
+- Data from other sources is still shown
+- The UI displays "retrying at HH:MM"
+- Signals continue from non-degraded sources
+
+**Senate eFTS degradation** is typically caused by DNS failures on efts.senate.gov.`,
+    trading_impact: "Signal generation continues from non-degraded sources. Congress signal shows as NEUTRAL if all sources degraded.",
+    phase_note: "Added in Phase 13.5 — circuit breaker for Senate eFTS.",
+  },
+
+  PRICE_CONDITION: {
+    term: "PRICE_CONDITION",
+    display: "PriceCondition",
+    short: "IBKR conditional stop: fires the stop-loss when the underlying stock price crosses a threshold, not the option premium.",
+    long: `**PriceCondition** is an IBKR order condition that fires a child order when the underlying stock reaches a specified price.
+
+**Why used for options brackets:**
+Option premium fluctuates with implied volatility even when the underlying hasn't moved. A premium-based stop can fire prematurely during IV spikes. A PriceCondition on the underlying stock avoids this "volatility whipsaw."
+
+**Phase 13.5 fix**: \`reqContractDetails()\` now used to verify \`conId > 0\` before building PriceCondition. Prior code used \`qualifyContracts()\`, which could return before metadata arrived, leaving \`conId=0\` and causing IBKR Error 321.
+
+**Downgrade path**: If qualification fails, SL leg falls back to option-premium stop and a \`[BRACKET-DOWNGRADE]\` log line is emitted.`,
+    source: "ib_insync PriceCondition · IBKR EWrapper",
+    trading_impact: "Prevents SL leg from firing on IV noise. Requires conId > 0 from reqContractDetails().",
+    related: ["IBKR_ERROR_321"],
+    phase_note: "Phase 9 introduced PriceCondition; Phase 13.5 fixed conId=0 bug.",
+  },
+
+  IBKR_ERROR_321: {
+    term: "IBKR_ERROR_321",
+    display: "IBKR Error 321",
+    short: "IBKR validation error: 'Invalid contract id' — caused by passing conId=0 to a PriceCondition before full qualification.",
+    long: `**IBKR Error 321** ("Error validating request — Invalid contract id") is thrown when an order references a contract with \`conId=0\`.
+
+**Root cause (Phase 9):**
+\`qualifyContracts()\` could return before \`conId\` was populated, leaving it at 0. IBKR rejected the bracket order.
+
+**Phase 13.5 fix:**
+Replaced with \`reqContractDetails()\`, which returns explicit contract details. We verify \`conId > 0\` before proceeding. If not, the condition is skipped with a \`[BRACKET-DOWNGRADE]\` audit log.
+
+**Error classification: FATAL** — not retried. This is a configuration error, not a connectivity blip.`,
+    source: "IBKR EWrapper error code 321 · ib_insync reqContractDetails()",
+    trading_impact: "Post-fix: PriceCondition has valid conId or SL downgrades gracefully to option-premium stop.",
+    related: ["PRICE_CONDITION"],
+    phase_note: "Added in Phase 13.5.",
+  },
 };
 
 /**

--- a/tcode/alpha_control_center/src/pages/Dashboard.tsx
+++ b/tcode/alpha_control_center/src/pages/Dashboard.tsx
@@ -293,6 +293,7 @@ interface IntelIndexEntry {
     symbol: string;
     change_pct: number;
     ok: boolean;
+    source?: string;  // DXY only: "live" | "uup_proxy" | "unavailable"
 }
 
 interface IntelPremarket {
@@ -328,6 +329,13 @@ interface IntelCongressTrade {
     within_48h: boolean;
 }
 
+interface CongressSourceStatus {
+    status: 'ok' | 'degraded' | 'disabled' | 'unknown';
+    last_success_at: string | null;
+    last_error: string | null;
+    next_retry_at?: string | null;
+}
+
 interface IntelCongress {
     signal: string;
     committee_weighted_buy_48h: boolean;
@@ -336,6 +344,8 @@ interface IntelCongress {
     filing_count: number;
     recent_count: number;
     recent_trades?: IntelCongressTrade[];
+    senate?: CongressSourceStatus;
+    house?: CongressSourceStatus;
 }
 
 interface IntelCorrelationRegime {
@@ -3767,9 +3777,23 @@ const PreMarketPanel = ({ intel, isLoading }: { intel: Intel | null; isLoading?:
                                 <>
                                     <div className="fill-row"><span>USDJPY</span><span>{changePctLabel(pm.fx.USDJPY.change_pct)}</span></div>
                                     <div className="fill-row"><span>EURUSD</span><span>{changePctLabel(pm.fx.EURUSD.change_pct)}</span></div>
-                                    <div className="fill-row"><span>DXY</span><span>{changePctLabel(pm.fx.DXY.change_pct)}</span></div>
+                                    <div className="fill-row">
+                                        <span><TermLabel term="DXY_SOURCE">DXY</TermLabel></span>
+                                        <span style={{display:'flex',alignItems:'center',gap:'6px'}}>
+                                            {pm.fx.DXY.ok ? changePctLabel(pm.fx.DXY.change_pct) : <span style={{color:'#f85149'}}>Unavailable</span>}
+                                            {pm.fx.DXY.source === 'live' && (
+                                                <span style={{background:'#1c4a1c',color:'#3fb950',fontSize:'10px',padding:'1px 5px',borderRadius:'3px'}}>DX-Y.NYB live</span>
+                                            )}
+                                            {pm.fx.DXY.source === 'uup_proxy' && (
+                                                <span style={{background:'#4a3a00',color:'#f0883e',fontSize:'10px',padding:'1px 5px',borderRadius:'3px'}}><TermLabel term="UUP_PROXY">UUP proxy</TermLabel></span>
+                                            )}
+                                            {(pm.fx.DXY.source === 'unavailable' || !pm.fx.DXY.ok) && (
+                                                <span style={{background:'#4a1c1c',color:'#f85149',fontSize:'10px',padding:'1px 5px',borderRadius:'3px'}}>Unavailable</span>
+                                            )}
+                                        </span>
+                                    </div>
                                     <div className="fill-row"><span>FX override</span><span style={{color:'#8b949e',fontSize:'11px'}}>Moves &gt;0.5% add ±0.20 to confidence</span></div>
-                                    <div className="fill-row"><span>Source</span><span style={{fontSize:'11px'}}>yfinance (2d history)</span></div>
+                                    <div className="fill-row"><span>Source</span><span style={{fontSize:'11px'}}>{pm.fx.DXY.source === 'uup_proxy' ? 'UUP ETF (DXY proxy) via yfinance' : pm.fx.DXY.source === 'live' ? 'DX-Y.NYB ICE futures via yfinance' : 'yfinance (2d history)'}</span></div>
                                 </>
                             )}
                             {drillTarget === 'TSLA' && pm && (
@@ -3923,7 +3947,23 @@ const PreMarketPanel = ({ intel, isLoading }: { intel: Intel | null; isLoading?:
                         <>
                             <div className="intel-row"><span className="intel-label">USDJPY</span><span>{changePctLabel(pm.fx.USDJPY.change_pct)}</span></div>
                             <div className="intel-row"><span className="intel-label">EURUSD</span><span>{changePctLabel(pm.fx.EURUSD.change_pct)}</span></div>
-                            <div className="intel-row"><span className="intel-label">DXY</span><span>{changePctLabel(pm.fx.DXY.change_pct)}</span></div>
+                            <div className="intel-row">
+                                <span className="intel-label"><TermLabel term="DXY_SOURCE">DXY</TermLabel></span>
+                                <span style={{display:'flex',alignItems:'center',gap:'4px'}}>
+                                    {pm.fx.DXY.ok ? changePctLabel(pm.fx.DXY.change_pct) : <span style={{color:'#f85149',fontSize:'11px'}}>Unavail</span>}
+                                    {pm.fx.DXY.source === 'live' && (
+                                        <span style={{background:'#1c4a1c',color:'#3fb950',fontSize:'9px',padding:'1px 4px',borderRadius:'3px'}}>live</span>
+                                    )}
+                                    {pm.fx.DXY.source === 'uup_proxy' && (
+                                        <Tooltip text="^DXY delisted. UUP ETF used as directional proxy. Click FX Barometer for details.">
+                                            <span style={{background:'#4a3a00',color:'#f0883e',fontSize:'9px',padding:'1px 4px',borderRadius:'3px',cursor:'help'}}><TermLabel term="UUP_PROXY">proxy</TermLabel></span>
+                                        </Tooltip>
+                                    )}
+                                    {(pm.fx.DXY.source === 'unavailable' || (!pm.fx.DXY.ok && !pm.fx.DXY.source)) && (
+                                        <span style={{background:'#4a1c1c',color:'#f85149',fontSize:'9px',padding:'1px 4px',borderRadius:'3px'}}>down</span>
+                                    )}
+                                </span>
+                            </div>
                         </>
                     ) : (
                         <div style={{color:'#8b949e',fontSize:'12px'}}>Awaiting data</div>
@@ -4135,40 +4175,77 @@ const IntelPanel = ({ intel, isLoading }: { intel: Intel | null; isLoading?: boo
                     <Tooltip text="STOCK Act filings: TSLA trades by Congress members within 48h, committee-weighted. Committee members (Senate Commerce / House Energy) = 2× weight. Buying boosts SENTIMENT confidence ×1.15; selling = ×0.85.">
                         <div className="intel-card-title">Congress Trades</div>
                     </Tooltip>
-                    {congress ? (
-                        <>
-                            <div className="intel-row">
-                                <span className="intel-label">Signal</span>
-                                <span style={{
-                                    color: congress.signal === 'BULLISH' ? '#3fb950' : congress.signal === 'BEARISH' ? '#f85149' : '#8b949e',
-                                    fontWeight: 600,
-                                }}>
-                                    {congress.signal}
-                                </span>
-                            </div>
-                            <div className="intel-row">
-                                <span className="intel-label">Recent (48h/$15k+)</span>
-                                <span style={{color: congress.recent_count > 0 ? '#f0883e' : '#8b949e'}}>{congress.recent_count}</span>
-                            </div>
-                            <div className="intel-row">
-                                <span className="intel-label">Total filings</span>
-                                <span style={{color:'#8b949e'}}>{congress.filing_count}</span>
-                            </div>
-                            {congress.committee_weighted_buy_48h && (
-                                <div className="intel-row"><span className="intel-label">Committee</span><span style={{color:'#3fb950',fontSize:'11px'}}>KEY CMTE BUYING</span></div>
-                            )}
-                            {congress.committee_weighted_sell_48h && (
-                                <div className="intel-row"><span className="intel-label">Committee</span><span style={{color:'#f85149',fontSize:'11px'}}>KEY CMTE SELLING</span></div>
-                            )}
-                            {congress.recent_trades && congress.recent_trades.slice(0, 2).map((t, i) => (
-                                <div key={i} className="intel-row" style={{fontSize:'10px',flexDirection:'column',alignItems:'flex-start',gap:'1px'}}>
-                                    <span style={{color:'#8b949e'}}>{t.name} — {t.transaction_type} {t.amount}</span>
-                                    <span style={{color:'#666'}}>{t.date_filed} {t.committee_weight >= 2 ? '(key cmte)' : ''}</span>
+                    {congress ? (() => {
+                        const senateDegraded = congress.senate?.status === 'degraded';
+                        const houseDegraded = congress.house?.status === 'disabled' || congress.house?.status === 'degraded';
+                        const bothDown = senateDegraded && houseDegraded;
+                        const senateNextRetry = congress.senate?.next_retry_at
+                            ? new Date(congress.senate.next_retry_at).toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'})
+                            : null;
+
+                        if (bothDown) {
+                            return (
+                                <>
+                                    <div style={{color:'#f85149',fontSize:'11px',padding:'4px 0'}}>
+                                        Congress data unavailable since {congress.senate?.last_success_at
+                                            ? new Date(congress.senate.last_success_at).toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'})
+                                            : 'session start'}
+                                    </div>
+                                    <div className="intel-stale" style={{color:'#f85149'}}>Both feeds degraded</div>
+                                </>
+                            );
+                        }
+
+                        return (
+                            <>
+                                <div className="intel-row">
+                                    <span className="intel-label">Signal</span>
+                                    <span style={{
+                                        color: congress.signal === 'BULLISH' ? '#3fb950' : congress.signal === 'BEARISH' ? '#f85149' : '#8b949e',
+                                        fontWeight: 600,
+                                    }}>
+                                        {congress.signal}
+                                    </span>
                                 </div>
-                            ))}
-                            <div className="intel-stale">Cached 1h · STOCK Act data</div>
-                        </>
-                    ) : (
+                                <div className="intel-row">
+                                    <span className="intel-label">Recent (48h/$15k+)</span>
+                                    <span style={{color: congress.recent_count > 0 ? '#f0883e' : '#8b949e'}}>{congress.recent_count}</span>
+                                </div>
+                                <div className="intel-row">
+                                    <span className="intel-label">Total filings</span>
+                                    <span style={{color:'#8b949e'}}>{congress.filing_count}</span>
+                                </div>
+                                {congress.committee_weighted_buy_48h && (
+                                    <div className="intel-row"><span className="intel-label">Committee</span><span style={{color:'#3fb950',fontSize:'11px'}}>KEY CMTE BUYING</span></div>
+                                )}
+                                {congress.committee_weighted_sell_48h && (
+                                    <div className="intel-row"><span className="intel-label">Committee</span><span style={{color:'#f85149',fontSize:'11px'}}>KEY CMTE SELLING</span></div>
+                                )}
+                                {congress.recent_trades && congress.recent_trades.slice(0, 2).map((t, i) => (
+                                    <div key={i} className="intel-row" style={{fontSize:'10px',flexDirection:'column',alignItems:'flex-start',gap:'1px'}}>
+                                        <span style={{color:'#8b949e'}}>{t.name} — {t.transaction_type} {t.amount}</span>
+                                        <span style={{color:'#666'}}>{t.date_filed} {t.committee_weight >= 2 ? '(key cmte)' : ''}</span>
+                                    </div>
+                                ))}
+                                {senateDegraded && (
+                                    <Tooltip text={congress.senate?.last_error ?? 'Senate eFTS endpoint unreachable'}>
+                                        <div style={{color:'#f0883e',fontSize:'10px',marginTop:'4px',cursor:'help'}}>
+                                            Senate feed <TermLabel term="SOURCE_DEGRADED">degraded</TermLabel>
+                                            {senateNextRetry && ` — retrying at ${senateNextRetry}`}
+                                        </div>
+                                    </Tooltip>
+                                )}
+                                {houseDegraded && (
+                                    <Tooltip text="House PTR transaction feed disabled pending annual URL discovery. See TODO(phase-13.5).">
+                                        <div style={{color:'#8b949e',fontSize:'10px',marginTop:'2px',cursor:'help'}}>
+                                            House feed: <TermLabel term="SOURCE_DEGRADED">annual discovery required</TermLabel>
+                                        </div>
+                                    </Tooltip>
+                                )}
+                                <div className="intel-stale">Cached 1h · STOCK Act data</div>
+                            </>
+                        );
+                    })() : (
                         <div className="intel-no-news">No STOCK Act data</div>
                     )}
                 </div>

--- a/tcode/alpha_control_center/tests/ux_integrity_contract.spec.ts
+++ b/tcode/alpha_control_center/tests/ux_integrity_contract.spec.ts
@@ -63,7 +63,10 @@ test.describe('Integrity API Contract', () => {
 
 test.describe('Integrity Dashboard No-Alert', () => {
   test('no INTEGRITY ALERT banner and all three dots green after load', async ({ page }) => {
-    await page.goto(BASE_URL, { waitUntil: 'networkidle' });
+    // Use 'load' not 'networkidle': the dashboard polls every few seconds so
+    // networkidle never fires. 'load' fires after initial resources; the
+    // waitForSelector below handles React render timing.
+    await page.goto(BASE_URL, { waitUntil: 'load' });
 
     // Wait for integrity bar to render
     await page.waitForSelector('.integrity-bar', { timeout: 10_000 });

--- a/tcode/alpha_engine/ingestion/congress_trades.py
+++ b/tcode/alpha_engine/ingestion/congress_trades.py
@@ -12,8 +12,14 @@ Why this signal exists:
 Data sources (free, public):
   - Senate: Senate Electronic Financial Disclosures (eFTS) JSON search API
     https://efts.senate.gov/LATEST/search-index
-  - House: House Disclosure Clerk periodic transaction reports (XML)
-    https://disclosures-clerk.house.gov/FinancialDisclosure
+  - House: House Disclosure Clerk annual ZIP (Phase 13.5 fix)
+    https://disclosures-clerk.house.gov/public_disc/financial-pdfs/{year}FD.zip
+    (The prior URL pattern ptr-pdfs/{year}FD.xml returned 404 as of 2026.)
+    NOTE: The ZIP contains a filing INDEX only — no per-transaction ticker data.
+    House PTR is currently DISABLED pending discovery of a transaction-level source.
+    TODO(phase-13.5): Investigate individual DocID PDFs or alternate data source
+    (QuiverQuant requires API key; OpenSecrets per-ticker endpoint needs auth).
+    Annual URL discovery: verify each January — pattern is financial-pdfs/{year}FD.zip
 
 Committee weighting rationale:
   Senate Commerce, Science & Transportation: oversees FCC, FTC, NHTSA, and EV/tech.
@@ -41,6 +47,30 @@ _CACHE_TS: float = 0.0
 _CACHE_TTL = 3600  # 1 hour — disclosures trickle in; no need to hammer gov servers
 
 _REQUEST_TIMEOUT = 10  # seconds
+
+# ── Senate eFTS circuit breaker state ────────────────────────────────────────
+# After 3 consecutive failures, mark degraded for 10 minutes to avoid hammering DNS.
+_SENATE_FAIL_COUNT: int = 0
+_SENATE_DEGRADED_UNTIL: float = 0.0
+_SENATE_LAST_SUCCESS_AT: Optional[str] = None
+_SENATE_LAST_ERROR: Optional[str] = None
+_SENATE_DEGRADED_RETRY_INTERVAL: float = 600  # 10 minutes
+_SENATE_MAX_RETRIES: int = 3
+_SENATE_RETRY_DELAYS: tuple = (1, 4, 16)  # exponential backoff seconds
+
+# ── House PTR URL pattern ─────────────────────────────────────────────────────
+# The old ptr-pdfs/{year}FD.xml path returned 404 as of 2026. The new ZIP is
+# available at financial-pdfs/{year}FD.zip but contains only a filing INDEX
+# (member names + DocIDs), NOT per-transaction ticker data.
+# Pattern: https://disclosures-clerk.house.gov/public_disc/financial-pdfs/{year}FD.zip
+# House PTR is DISABLED until a transaction-level source is identified.
+# Source: verified 2026-04-14 that ZIP returns 200 but has no <Asset>/<Transaction> nodes.
+HOUSE_PTR_URL_PATTERN = "https://disclosures-clerk.house.gov/public_disc/financial-pdfs/{year}FD.zip"
+_HOUSE_DISABLED_REASON = (
+    "House PTR feed disabled — annual URL discovery required. "
+    "The {year}FD.zip index contains filing metadata only (no per-ticker transaction data). "
+    "See TODO(phase-13.5) in congress_trades.py."
+)
 
 # ── Committee membership: 119th Congress (2025–2026) ──────────────────────────
 # Source: congress.gov committee listings, updated manually each session.
@@ -163,10 +193,25 @@ def _fetch_senate_ptrs() -> list[dict]:
     generation we use the metadata + senator/committee info.
 
     Reference: https://efts.senate.gov — no auth required, rate limit unclear.
+
+    Resilience (Phase 13.5):
+      - 3 retry attempts with exponential backoff (1s, 4s, 16s)
+      - After 3 consecutive failures, source is marked degraded for 10 minutes
+      - Logs [CONGRESS-DEGRADED] on circuit open; [CONGRESS-RECOVERED] on success
     """
-    now = datetime.now(timezone.utc)
-    from_date = (now - timedelta(days=3)).strftime("%Y-%m-%d")  # 3-day window for buffer
-    to_date = now.strftime("%Y-%m-%d")
+    global _SENATE_FAIL_COUNT, _SENATE_DEGRADED_UNTIL, _SENATE_LAST_SUCCESS_AT, _SENATE_LAST_ERROR
+
+    now_ts = time.time()
+
+    # Circuit breaker: if degraded, don't attempt until cooldown expires
+    if _SENATE_DEGRADED_UNTIL > 0 and now_ts < _SENATE_DEGRADED_UNTIL:
+        next_retry = datetime.fromtimestamp(_SENATE_DEGRADED_UNTIL, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        logger.debug("[CONGRESS-DEGRADED] Senate eFTS circuit open — next_retry_at=%s", next_retry)
+        return []
+
+    now_dt = datetime.now(timezone.utc)
+    from_date = (now_dt - timedelta(days=3)).strftime("%Y-%m-%d")
+    to_date = now_dt.strftime("%Y-%m-%d")
 
     url = "https://efts.senate.gov/LATEST/search-index"
     params = {
@@ -177,15 +222,40 @@ def _fetch_senate_ptrs() -> list[dict]:
         "category": "Periodic Transactions Report",
         "results": "25",
     }
-    try:
-        resp = requests.get(url, params=params, timeout=_REQUEST_TIMEOUT)
-        resp.raise_for_status()
-        data = resp.json()
-    except requests.RequestException as e:
-        logger.warning(f"Senate eFTS fetch failed: {e}")
-        return []
-    except (json.JSONDecodeError, ValueError) as e:
-        logger.warning(f"Senate eFTS JSON parse failed: {e}")
+
+    last_exc: Optional[Exception] = None
+    for attempt in range(_SENATE_MAX_RETRIES):
+        try:
+            resp = requests.get(url, params=params, timeout=_REQUEST_TIMEOUT)
+            resp.raise_for_status()
+            data = resp.json()
+            # Success — reset circuit breaker
+            if _SENATE_FAIL_COUNT > 0:
+                logger.info("[CONGRESS-RECOVERED] Senate eFTS recovered after %d failures", _SENATE_FAIL_COUNT)
+            _SENATE_FAIL_COUNT = 0
+            _SENATE_DEGRADED_UNTIL = 0.0
+            _SENATE_LAST_SUCCESS_AT = now_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+            _SENATE_LAST_ERROR = None
+            break
+        except (requests.RequestException, json.JSONDecodeError, ValueError) as e:
+            last_exc = e
+            if attempt < _SENATE_MAX_RETRIES - 1:
+                delay = _SENATE_RETRY_DELAYS[attempt]
+                logger.debug("Senate eFTS attempt %d/%d failed (%s), retrying in %ds",
+                             attempt + 1, _SENATE_MAX_RETRIES, e, delay)
+                time.sleep(delay)
+    else:
+        # All _SENATE_MAX_RETRIES attempts exhausted — open circuit immediately.
+        # The spec says "after 3 failures, mark degraded": those 3 failures are
+        # the 3 retry attempts within a single call (not 3 separate calls).
+        _SENATE_FAIL_COUNT += 1
+        _SENATE_LAST_ERROR = str(last_exc)
+        _SENATE_DEGRADED_UNTIL = time.time() + _SENATE_DEGRADED_RETRY_INTERVAL
+        next_retry = datetime.fromtimestamp(_SENATE_DEGRADED_UNTIL, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        logger.warning(
+            "[CONGRESS-DEGRADED] reason=%s next_retry_at=%s",
+            _SENATE_LAST_ERROR, next_retry,
+        )
         return []
 
     trades = []
@@ -224,41 +294,36 @@ def _fetch_senate_ptrs() -> list[dict]:
 
 def _fetch_house_ptrs() -> list[dict]:
     """
-    Fetch House Periodic Transaction Reports from the disclosure clerk.
+    Fetch House Periodic Transaction Reports.
 
-    The House Clerk publishes annual PTR data as XML. We download the current
-    year's data and filter for TSLA transactions filed in the last 48 hours.
+    STATUS: DISABLED as of Phase 13.5 (2026-04-14).
 
-    XML format (House eFD system, standardized 2020+):
-      <FinancialDisclosure>
-        <Member><First/><Last/><State/><District/></Member>
-        <Transactions>
-          <Transaction>
-            <FilingDate>MM/DD/YYYY</FilingDate>
-            <TransactionDate>MM/DD/YYYY</TransactionDate>
-            <Asset>Tesla, Inc. [TSLA]</Asset>
-            <TransactionType>P|S</TransactionType>
-            <Amount>$15,001 - $50,000</Amount>
-            <Committee>...</Committee>
-          </Transaction>
-        </Transactions>
-      </FinancialDisclosure>
+    Investigation found:
+      - https://disclosures-clerk.house.gov/public_disc/ptr-pdfs/{year}FD.xml → 404
+      - https://disclosures-clerk.house.gov/public_disc/financial-pdfs/{year}FD.zip → 200
+        BUT the ZIP contains only a filing INDEX (member names + DocIDs), not
+        per-transaction ticker/amount data. The <Asset>, <TransactionType>, and
+        <Amount> fields expected by _parse_house_xml() are absent.
+      - QuiverQuant API requires authentication (no free unauthenticated endpoint).
+      - JSON API at /api/v1/public_disc/ptr → 404.
 
-    Note: House system does not provide a real-time JSON API; the XML is
-    updated incrementally. For live use, cache is 1 hour.
+    TODO(phase-13.5): Identify a transaction-level source for House PTRs.
+    Options to investigate next:
+      a) Fetch individual DocID PDFs (requires PDF parsing library — pyPDF2 or pdfplumber)
+      b) Obtain QuiverQuant or OpenSecrets API key
+      c) Check if eFTS/House adds per-transaction XML by next annual update
+    Annual URL: verify HOUSE_PTR_URL_PATTERN pattern each January.
+
+    Returns empty list with a logged warning so the Congress card shows
+    "House feed: annual URL discovery required" rather than silently missing data.
     """
     year = datetime.now(timezone.utc).year
-    url = f"https://disclosures-clerk.house.gov/public_disc/ptr-pdfs/{year}FD.xml"
-
-    try:
-        resp = requests.get(url, timeout=_REQUEST_TIMEOUT)
-        resp.raise_for_status()
-        xml_text = resp.text
-    except requests.RequestException as e:
-        logger.warning(f"House PTR fetch failed ({url}): {e}")
-        return []
-
-    return _parse_house_xml(xml_text)
+    logger.warning(
+        "[HOUSE-PTR-DISABLED] House PTR transaction feed unavailable (Phase 13.5). "
+        "ZIP index at %s exists but lacks per-ticker data. See TODO(phase-13.5).",
+        HOUSE_PTR_URL_PATTERN.format(year=year),
+    )
+    return []
 
 
 def _parse_house_xml(xml_text: str) -> list[dict]:
@@ -338,6 +403,29 @@ def _parse_house_xml(xml_text: str) -> list[dict]:
     return trades
 
 
+def get_senate_status() -> dict:
+    """
+    Return current Senate eFTS source status for /api/intel congress sub-object.
+
+    Status values:
+      "ok"       — last fetch succeeded
+      "degraded" — circuit open (3+ failures), retrying at next_retry_at
+      "unknown"  — never successfully fetched in this process lifetime
+    """
+    now_ts = time.time()
+    if _SENATE_DEGRADED_UNTIL > 0 and now_ts < _SENATE_DEGRADED_UNTIL:
+        next_retry = datetime.fromtimestamp(_SENATE_DEGRADED_UNTIL, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        return {
+            "status": "degraded",
+            "last_success_at": _SENATE_LAST_SUCCESS_AT,
+            "last_error": _SENATE_LAST_ERROR,
+            "next_retry_at": next_retry,
+        }
+    if _SENATE_LAST_SUCCESS_AT:
+        return {"status": "ok", "last_success_at": _SENATE_LAST_SUCCESS_AT, "last_error": None}
+    return {"status": "unknown", "last_success_at": None, "last_error": _SENATE_LAST_ERROR}
+
+
 def get_congress_trades() -> dict:
     """
     Return congress trade intelligence. Cached 1 hour.
@@ -351,6 +439,8 @@ def get_congress_trades() -> dict:
       sentiment_multiplier: float — ×1.15 for buying, ×0.85 for selling, 1.0 neutral
       filing_count: int
       last_fetch_ts: float
+      senate: {status, last_success_at, last_error}  — source health (Phase 13.5)
+      house:  {status, last_success_at, last_error}  — "disabled" until PTR source found
     """
     global _CACHE, _CACHE_TS
     now = time.time()
@@ -408,6 +498,13 @@ def get_congress_trades() -> dict:
         "filing_count": len(all_trades),
         "recent_count": len(recent),
         "last_fetch_ts": now,
+        # Source health sub-objects (Phase 13.5) — used by /api/intel and Congress card
+        "senate": get_senate_status(),
+        "house": {
+            "status": "disabled",
+            "last_success_at": None,
+            "last_error": _HOUSE_DISABLED_REASON.format(year=datetime.now(timezone.utc).year),
+        },
     }
     _CACHE = result
     _CACHE_TS = now

--- a/tcode/alpha_engine/ingestion/ibkr_order.py
+++ b/tcode/alpha_engine/ingestion/ibkr_order.py
@@ -63,6 +63,49 @@ logger.addHandler(_stderr_handler)
 CONNECT_TIMEOUT = int(os.getenv("IBKR_CONNECT_TIMEOUT", "10"))
 ORDER_WAIT_SEC = 2.0
 
+# ── IBKR error classification ─────────────────────────────────────────────────
+# Classifies IBKR EWrapper error codes as TRANSIENT (safe to retry) or FATAL
+# (configuration/validation errors that will never succeed with the same params).
+# Error 321: "Error validating request — Invalid contract id"
+#   Root cause: conId=0 passed to a PriceCondition (contract not fully qualified).
+#   This is a FATAL configuration error — retrying with conId=0 will always fail.
+#   Fix: use reqContractDetails() to get a verified conId before building PriceCondition.
+_IBKR_FATAL_ERRORS: frozenset = frozenset({
+    321,   # Invalid contract id (e.g., PriceCondition with conId=0)
+    200,   # No security definition found
+    10168, # Requested market data is not subscribed
+    10197, # No market data during competing live session
+})
+
+_IBKR_TRANSIENT_ERRORS: frozenset = frozenset({
+    1100,  # Connectivity between IB and TWS has been lost
+    1101,  # Connectivity between IB and TWS has been restored
+    1102,  # Connectivity between IB and TWS has been restored (data lost)
+    2110,  # Connectivity between TWS and server is broken
+    504,   # Not connected
+})
+
+
+def classify_ibkr_error(error_code: int, message: str = "") -> str:
+    """
+    Classify an IBKR EWrapper error as 'fatal', 'transient', or 'unknown'.
+
+    Fatal errors are configuration/validation errors that will not succeed on retry
+    with the same parameters. The engine must NOT retry these — log and escalate.
+
+    Transient errors indicate connectivity issues that may resolve on reconnect.
+
+    Usage in error callback:
+        category = classify_ibkr_error(errorCode, errorString)
+        if category == 'fatal':
+            logger.error("[IBKR-FATAL] error=%d msg=%s — not retrying", errorCode, errorString)
+    """
+    if error_code in _IBKR_FATAL_ERRORS:
+        return "fatal"
+    if error_code in _IBKR_TRANSIENT_ERRORS:
+        return "transient"
+    return "unknown"
+
 
 # ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -301,33 +344,46 @@ def place_bracket_order(
         # ── Apply underlying PriceCondition if requested ──────────────────────
         if underlying_stop_symbol and underlying_stop_price > 0:
             underlying_contract = Stock(underlying_stop_symbol, "SMART", "USD")
-            q_under = ib.qualifyContracts(underlying_contract)
-            if q_under:
-                underlying_contract = q_under[0]
-                # Long CALL: trigger when underlying DROPS below stop → isMore=False
-                # Long PUT:  trigger when underlying RISES above stop → isMore=True
-                is_put  = right == "P"
-                is_more = is_put
-                sl_order.conditions = [
-                    PriceCondition(
-                        conId=underlying_contract.conId,
-                        exch="SMART",
-                        price=underlying_stop_price,
-                        isMore=is_more,
+            # Phase 13.5 fix: use reqContractDetails to guarantee conId is populated.
+            # qualifyContracts() can return before metadata arrives, leaving conId=0,
+            # which causes IBKR Error 321 "Invalid contract id" when PriceCondition
+            # is built with conId=0.
+            try:
+                details = ib.reqContractDetails(underlying_contract)
+                if details and len(details) > 0 and details[0].contract.conId > 0:
+                    underlying_contract = details[0].contract
+                    # Long CALL: trigger when underlying DROPS below stop → isMore=False
+                    # Long PUT:  trigger when underlying RISES above stop → isMore=True
+                    is_put  = right == "P"
+                    is_more = is_put
+                    sl_order.conditions = [
+                        PriceCondition(
+                            conId=underlying_contract.conId,
+                            exch="SMART",
+                            price=underlying_stop_price,
+                            isMore=is_more,
+                        )
+                    ]
+                    sl_order.conditionsCancelOrder = False
+                    logger.info(
+                        "Underlying stop condition: %s conId=%d %s %.2f (isMore=%s)",
+                        underlying_stop_symbol,
+                        underlying_contract.conId,
+                        "rises above" if is_more else "drops below",
+                        underlying_stop_price,
+                        is_more,
                     )
-                ]
-                sl_order.conditionsCancelOrder = False
-                logger.info(
-                    "Underlying stop condition: %s %s %.2f (isMore=%s)",
-                    underlying_stop_symbol,
-                    "rises above" if is_more else "drops below",
-                    underlying_stop_price,
-                    is_more,
-                )
-            else:
+                else:
+                    logger.warning(
+                        "[CONTRACT-QUAL-FAIL] symbol=%s reason=empty_details — "
+                        "[BRACKET-DOWNGRADE] SL uses option-premium stop only (no PriceCondition)",
+                        underlying_stop_symbol,
+                    )
+            except Exception as qual_exc:
                 logger.warning(
-                    "Could not qualify underlying %s — using option-premium SL only",
-                    underlying_stop_symbol,
+                    "[CONTRACT-QUAL-FAIL] symbol=%s reason=%s — "
+                    "[BRACKET-DOWNGRADE] SL uses option-premium stop only (no PriceCondition)",
+                    underlying_stop_symbol, qual_exc,
                 )
 
         # ── Place all three orders ────────────────────────────────────────────

--- a/tcode/alpha_engine/ingestion/macro_regime.py
+++ b/tcode/alpha_engine/ingestion/macro_regime.py
@@ -2,9 +2,17 @@
 """
 Macro Regime Detection: Fed rate, yield curve, VIX term structure, trade tensions.
 Classifies the macro environment as RISK_ON, RISK_OFF, or NEUTRAL.
+
+DXY sourcing (Phase 13.5):
+  ^DXY was delisted from yfinance. We now try:
+    1. DX-Y.NYB  — ICE US Dollar Index futures continuous contract (primary)
+    2. UUP       — Invesco DB US Dollar Index Bullish ETF (proxy; ~1:1 directional)
+  If both fail, dxy_status="unavailable" and dxy_trend="NEUTRAL" (no stale zeros).
+  Cache: 5 min during US hours, 15 min off-hours.
 """
 import time
 import logging
+from datetime import datetime, timezone
 from typing import Optional
 
 logger = logging.getLogger("MacroRegime")
@@ -16,6 +24,93 @@ _VIX_TTL = 300     # 5 minutes for VIX term structure
 
 _vix_cache: Optional[dict] = None
 _vix_cache_ts: float = 0.0
+
+# DXY cache — separate because it has a different TTL than the macro block
+_dxy_cache: Optional[dict] = None
+_dxy_cache_ts: float = 0.0
+
+
+def _dxy_ttl() -> float:
+    """5 min during US market hours (9:30–16:00 ET), 15 min otherwise."""
+    et_hour = datetime.now(timezone.utc).hour - 4  # rough EDT offset
+    if 9 <= et_hour < 16:
+        return 300
+    return 900
+
+
+def _fetch_dxy() -> dict:
+    """
+    Fetch US Dollar Index.
+
+    Tries DX-Y.NYB (ICE futures) first. Falls back to UUP (ETF proxy) if that
+    fails or returns empty. Returns status field so callers can show a source badge.
+
+    Never returns a stale value beyond the TTL — callers are responsible for
+    checking _dxy_cache_ts.
+    """
+    global _dxy_cache, _dxy_cache_ts
+    now = time.time()
+    if _dxy_cache is not None and now - _dxy_cache_ts < _dxy_ttl():
+        return _dxy_cache
+
+    try:
+        import yfinance as yf
+
+        # Primary: ICE US Dollar Index futures
+        try:
+            hist = yf.Ticker("DX-Y.NYB").history(period="2d")
+            if not hist.empty and len(hist) >= 1:
+                price = float(hist["Close"].iloc[-1])
+                chg_pct = None
+                if len(hist) >= 2:
+                    prev = float(hist["Close"].iloc[-2])
+                    chg_pct = round((price - prev) / prev * 100, 3) if prev else None
+                result = {
+                    "dxy": round(price, 3),
+                    "dxy_change_pct": chg_pct,
+                    "dxy_status": "live",
+                    "dxy_source": "DX-Y.NYB",
+                }
+                _dxy_cache = result
+                _dxy_cache_ts = now
+                return result
+        except Exception as e:
+            logger.debug("DX-Y.NYB fetch failed: %s", e)
+
+        # Fallback: UUP ETF proxy
+        try:
+            hist = yf.Ticker("UUP").history(period="2d")
+            if not hist.empty and len(hist) >= 1:
+                price = float(hist["Close"].iloc[-1])
+                chg_pct = None
+                if len(hist) >= 2:
+                    prev = float(hist["Close"].iloc[-2])
+                    chg_pct = round((price - prev) / prev * 100, 3) if prev else None
+                result = {
+                    "dxy": round(price, 3),
+                    "dxy_change_pct": chg_pct,
+                    "dxy_status": "uup_proxy",
+                    "dxy_source": "UUP",
+                }
+                _dxy_cache = result
+                _dxy_cache_ts = now
+                return result
+        except Exception as e:
+            logger.debug("UUP fallback fetch failed: %s", e)
+
+    except ImportError:
+        pass
+
+    logger.warning("[DXY-UNAVAILABLE] Both DX-Y.NYB and UUP failed at %s", time.strftime("%Y-%m-%dT%H:%M:%SZ"))
+    result = {
+        "dxy": None,
+        "dxy_change_pct": None,
+        "dxy_status": "unavailable",
+        "dxy_source": None,
+    }
+    _dxy_cache = result
+    _dxy_cache_ts = now
+    return result
 
 
 def _fetch_macro_data() -> dict:
@@ -77,6 +172,16 @@ def _fetch_macro_data() -> dict:
                 result["china_risk"] = round(max(0, -fxi_change * 2), 1)  # 0-10 scale
         except Exception:
             pass
+
+        # DXY: use resilient fetcher (DX-Y.NYB primary, UUP proxy fallback)
+        dxy_data = _fetch_dxy()
+        if dxy_data["dxy_status"] != "unavailable" and dxy_data.get("dxy_change_pct") is not None:
+            chg = dxy_data["dxy_change_pct"]
+            result["dxy_trend"] = "RISING" if chg > 0.2 else "FALLING" if chg < -0.2 else "NEUTRAL"
+        result["dxy"] = dxy_data.get("dxy")
+        result["dxy_change_pct"] = dxy_data.get("dxy_change_pct")
+        result["dxy_status"] = dxy_data.get("dxy_status", "unavailable")
+        result["dxy_source"] = dxy_data.get("dxy_source")
 
         return result
     except Exception as e:

--- a/tcode/alpha_engine/ingestion/premarket.py
+++ b/tcode/alpha_engine/ingestion/premarket.py
@@ -96,7 +96,15 @@ def _fetch_premarket() -> dict:
         sse  = _fetch_index(yf, "000001.SS")  # Shanghai Composite
         usdjpy = _fetch_index(yf, "USDJPY=X")
         eurusd = _fetch_index(yf, "EURUSD=X")
-        dxy    = _fetch_index(yf, "^DXY")
+        # DXY: ^DXY is delisted. Use resilient fetcher (DX-Y.NYB primary, UUP proxy fallback).
+        from ingestion.macro_regime import _fetch_dxy as _get_dxy
+        _dxy_data = _get_dxy()
+        dxy = {
+            "symbol": _dxy_data.get("dxy_source") or "DXY",
+            "change_pct": _dxy_data.get("dxy_change_pct") or 0.0,
+            "ok": _dxy_data.get("dxy_status") not in (None, "unavailable"),
+            "source": _dxy_data.get("dxy_status", "unavailable"),  # "live" | "uup_proxy" | "unavailable"
+        }
 
         # ── TSLA pre/post-market ───────────────────────────────────────────
         tsla_premarket: dict = {"change_pct": 0.0, "volume": 0, "ok": False}
@@ -199,7 +207,7 @@ def _fetch_premarket() -> dict:
             "fx": {
                 "USDJPY": usdjpy,
                 "EURUSD": eurusd,
-                "DXY": dxy,
+                "DXY": dxy,  # includes .source: "live" | "uup_proxy" | "unavailable"
             },
             "tsla_premarket": tsla_premarket,
             # ── Top-level composite ──

--- a/tcode/alpha_engine/tests/test_congress_degraded.py
+++ b/tcode/alpha_engine/tests/test_congress_degraded.py
@@ -1,0 +1,223 @@
+"""
+Tests for Phase 13.5: Congress data-source resilience.
+
+Covers:
+  - Senate eFTS retry with exponential backoff (3 attempts)
+  - Circuit breaker opens after 3 failures
+  - Circuit breaker blocks requests during cooldown
+  - Recovery resets circuit state
+  - get_congress_trades() includes senate/house status sub-objects
+  - House PTR disabled (no fake data)
+  - No stale cache returned past TTL on degraded source
+"""
+import sys
+import time
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import patch, MagicMock, call
+
+sys.path.insert(0, "/home/builder/src/gpfiles/tcode/alpha_engine")
+
+import ingestion.congress_trades as ct
+from ingestion.congress_trades import (
+    get_senate_status,
+    get_congress_trades,
+    _fetch_senate_ptrs,
+    _fetch_house_ptrs,
+)
+
+
+def _reset_senate_state():
+    """Reset all Senate circuit breaker module globals between tests."""
+    ct._SENATE_FAIL_COUNT = 0
+    ct._SENATE_DEGRADED_UNTIL = 0.0
+    ct._SENATE_LAST_SUCCESS_AT = None
+    ct._SENATE_LAST_ERROR = None
+    ct._CACHE = None
+    ct._CACHE_TS = 0.0
+
+
+class TestSenateCircuitBreaker(unittest.TestCase):
+    """Senate eFTS retry + circuit breaker behavior."""
+
+    def setUp(self):
+        _reset_senate_state()
+
+    def test_successful_fetch_resets_fail_count(self):
+        """A successful fetch after prior failures resets the circuit breaker."""
+        ct._SENATE_FAIL_COUNT = 2  # simulated prior failures
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"hits": {"hits": []}}
+        mock_resp.raise_for_status.return_value = None
+
+        with patch("requests.get", return_value=mock_resp):
+            _fetch_senate_ptrs()
+
+        self.assertEqual(ct._SENATE_FAIL_COUNT, 0)
+        self.assertEqual(ct._SENATE_DEGRADED_UNTIL, 0.0)
+        self.assertIsNotNone(ct._SENATE_LAST_SUCCESS_AT)
+
+    def test_three_failures_open_circuit(self):
+        """After 3 consecutive failures, circuit is opened with a cooldown timestamp."""
+        import requests as req_module
+        with patch("requests.get", side_effect=req_module.ConnectionError("DNS resolution failed")), \
+             patch("ingestion.congress_trades.time.sleep"):  # don't actually wait
+            result = _fetch_senate_ptrs()
+
+        self.assertEqual(result, [])
+        self.assertGreater(ct._SENATE_DEGRADED_UNTIL, time.time())
+        self.assertIsNotNone(ct._SENATE_LAST_ERROR)
+
+    def test_circuit_open_blocks_requests(self):
+        """When circuit is open, no HTTP requests are attempted."""
+        # Force circuit open
+        ct._SENATE_DEGRADED_UNTIL = time.time() + 600
+
+        with patch("requests.get") as mock_get:
+            result = _fetch_senate_ptrs()
+
+        mock_get.assert_not_called()
+        self.assertEqual(result, [])
+
+    def test_retry_attempts_before_circuit_open(self):
+        """Exactly 3 HTTP requests are attempted before circuit opens."""
+        import requests as req_module
+        with patch("requests.get", side_effect=req_module.Timeout("Timeout")) as mock_get, \
+             patch("ingestion.congress_trades.time.sleep"):
+            _fetch_senate_ptrs()
+
+        # Should have attempted _SENATE_MAX_RETRIES times
+        self.assertEqual(mock_get.call_count, ct._SENATE_MAX_RETRIES)
+
+    def test_get_senate_status_ok_after_success(self):
+        """get_senate_status() returns 'ok' after a successful fetch."""
+        ct._SENATE_LAST_SUCCESS_AT = "2026-04-14T10:00:00Z"
+        ct._SENATE_DEGRADED_UNTIL = 0.0
+        ct._SENATE_FAIL_COUNT = 0
+
+        status = get_senate_status()
+        self.assertEqual(status["status"], "ok")
+        self.assertEqual(status["last_success_at"], "2026-04-14T10:00:00Z")
+
+    def test_get_senate_status_degraded_during_cooldown(self):
+        """get_senate_status() returns 'degraded' while circuit is open."""
+        ct._SENATE_DEGRADED_UNTIL = time.time() + 600
+        ct._SENATE_LAST_ERROR = "NameResolutionError"
+
+        status = get_senate_status()
+        self.assertEqual(status["status"], "degraded")
+        self.assertIn("next_retry_at", status)
+        self.assertEqual(status["last_error"], "NameResolutionError")
+
+    def test_get_senate_status_unknown_before_any_fetch(self):
+        """get_senate_status() returns 'unknown' before any successful fetch."""
+        status = get_senate_status()
+        self.assertEqual(status["status"], "unknown")
+
+    def test_cooldown_expires_allows_probe(self):
+        """After cooldown, the circuit half-opens and allows one probe."""
+        # Expired cooldown
+        ct._SENATE_DEGRADED_UNTIL = time.time() - 1  # expired 1 second ago
+        ct._SENATE_FAIL_COUNT = 3
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"hits": {"hits": []}}
+        mock_resp.raise_for_status.return_value = None
+
+        with patch("requests.get", return_value=mock_resp):
+            result = _fetch_senate_ptrs()
+
+        # Should have succeeded and reset state
+        self.assertEqual(ct._SENATE_FAIL_COUNT, 0)
+
+
+class TestHousePTRDisabled(unittest.TestCase):
+    """House PTR feed is disabled in Phase 13.5."""
+
+    def setUp(self):
+        _reset_senate_state()
+
+    def test_house_ptr_returns_empty_list(self):
+        """_fetch_house_ptrs() returns empty list (no fake data)."""
+        result = _fetch_house_ptrs()
+        self.assertEqual(result, [])
+
+    def test_house_status_in_congress_trades(self):
+        """get_congress_trades() includes house status sub-object with 'disabled'."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"hits": {"hits": []}}
+        mock_resp.raise_for_status.return_value = None
+
+        with patch("requests.get", return_value=mock_resp):
+            result = get_congress_trades()
+
+        self.assertIn("house", result)
+        self.assertEqual(result["house"]["status"], "disabled")
+        self.assertIsNone(result["house"]["last_success_at"])
+        self.assertIsNotNone(result["house"]["last_error"])  # explains why disabled
+
+    def test_senate_status_in_congress_trades(self):
+        """get_congress_trades() includes senate status sub-object."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"hits": {"hits": []}}
+        mock_resp.raise_for_status.return_value = None
+
+        with patch("requests.get", return_value=mock_resp):
+            result = get_congress_trades()
+
+        self.assertIn("senate", result)
+        self.assertIn("status", result["senate"])
+
+
+class TestCongressTradesDegradedSignal(unittest.TestCase):
+    """Signal emission is NEUTRAL when all sources are degraded."""
+
+    def setUp(self):
+        _reset_senate_state()
+
+    def test_neutral_signal_when_senate_degraded(self):
+        """No data from senate → signal is NEUTRAL, sentiment_multiplier is 1.0."""
+        # Force circuit open
+        ct._SENATE_DEGRADED_UNTIL = time.time() + 600
+
+        result = get_congress_trades()
+
+        self.assertEqual(result["signal"], "NEUTRAL")
+        self.assertAlmostEqual(result["sentiment_multiplier"], 1.0, places=2)
+        self.assertEqual(result["filing_count"], 0)
+
+    def test_signal_still_emitted_from_senate_when_ok(self):
+        """With a buy filing from Senate, signal is BULLISH even though House is disabled."""
+        now_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {
+            "hits": {
+                "hits": [
+                    {
+                        "_source": {
+                            "first_name": "Roger",
+                            "last_name": "Wicker",
+                            "date_filed": now_str,
+                            "transaction_type": "PURCHASE",
+                            "amount": "$50,001 - $100,000",
+                            "committee": "Senate Commerce, Science, and Transportation",
+                            "link": "",
+                        }
+                    }
+                ]
+            }
+        }
+
+        with patch("requests.get", return_value=mock_resp):
+            result = get_congress_trades()
+
+        # Committee member buying in 48h → BULLISH
+        self.assertEqual(result["signal"], "BULLISH")
+        self.assertAlmostEqual(result["sentiment_multiplier"], 1.15, places=2)
+        self.assertTrue(result["committee_weighted_buy_48h"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tcode/alpha_engine/tests/test_dxy_fallback.py
+++ b/tcode/alpha_engine/tests/test_dxy_fallback.py
@@ -1,0 +1,182 @@
+"""
+Tests for Phase 13.5: DXY fallback chain in macro_regime.py and premarket.py
+
+Covers:
+  - DX-Y.NYB primary succeeds → dxy_status="live"
+  - DX-Y.NYB fails, UUP succeeds → dxy_status="uup_proxy"
+  - Both fail → dxy_status="unavailable", dxy=None (no fake zeros)
+  - get_macro_regime() propagates dxy_status into macro result
+  - premarket.py DXY dict has source field
+"""
+import sys
+import time
+import unittest
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, "/home/builder/src/gpfiles/tcode/alpha_engine")
+
+import ingestion.macro_regime as mr
+
+
+def _make_hist(price: float, n_rows: int = 2):
+    """Create a minimal mock yfinance history DataFrame with `n_rows` rows."""
+    import pandas as pd
+    closes = [price * 0.99, price] if n_rows >= 2 else [price]
+    return pd.DataFrame({"Close": closes})
+
+
+def _empty_hist():
+    """Return an empty DataFrame (simulates yfinance returning nothing)."""
+    import pandas as pd
+    return pd.DataFrame({"Close": []})
+
+
+class TestDxyFallback(unittest.TestCase):
+    def setUp(self):
+        # Reset module-level cache before each test
+        mr._dxy_cache = None
+        mr._dxy_cache_ts = 0.0
+
+    def test_primary_dxy_nyb_succeeds(self):
+        """When DX-Y.NYB returns valid data, status is 'live' and source is 'DX-Y.NYB'."""
+        mock_ticker = MagicMock()
+        mock_ticker.history.return_value = _make_hist(104.5)
+
+        with patch("yfinance.Ticker", return_value=mock_ticker):
+            result = mr._fetch_dxy()
+
+        self.assertEqual(result["dxy_status"], "live")
+        self.assertEqual(result["dxy_source"], "DX-Y.NYB")
+        self.assertIsNotNone(result["dxy"])
+        self.assertGreater(result["dxy"], 0)
+
+    def test_dxy_nyb_fails_uup_succeeds(self):
+        """When DX-Y.NYB fails and UUP returns data, status is 'uup_proxy'."""
+        call_count = {"n": 0}
+
+        def mock_ticker(symbol):
+            t = MagicMock()
+            call_count["n"] += 1
+            if symbol == "DX-Y.NYB":
+                t.history.side_effect = Exception("No data")
+            elif symbol == "UUP":
+                t.history.return_value = _make_hist(28.3)
+            return t
+
+        with patch("yfinance.Ticker", side_effect=mock_ticker):
+            result = mr._fetch_dxy()
+
+        self.assertEqual(result["dxy_status"], "uup_proxy")
+        self.assertEqual(result["dxy_source"], "UUP")
+        self.assertIsNotNone(result["dxy"])
+
+    def test_both_fail_returns_unavailable(self):
+        """When both DX-Y.NYB and UUP fail, dxy=None and status='unavailable'."""
+        def mock_ticker(symbol):
+            t = MagicMock()
+            t.history.return_value = _empty_hist()
+            return t
+
+        with patch("yfinance.Ticker", side_effect=mock_ticker):
+            result = mr._fetch_dxy()
+
+        self.assertEqual(result["dxy_status"], "unavailable")
+        self.assertIsNone(result["dxy"])
+        self.assertIsNone(result["dxy_change_pct"])
+        # Crucially: no stale zeros substituted
+        self.assertNotEqual(result.get("dxy"), 0.0)
+
+    def test_both_fail_with_exceptions(self):
+        """Exceptions on both sources also yield unavailable (no stale zeros)."""
+        def mock_ticker(symbol):
+            t = MagicMock()
+            t.history.side_effect = RuntimeError("Network error")
+            return t
+
+        with patch("yfinance.Ticker", side_effect=mock_ticker):
+            result = mr._fetch_dxy()
+
+        self.assertEqual(result["dxy_status"], "unavailable")
+        self.assertIsNone(result["dxy"])
+
+    def test_dxy_status_propagates_to_macro_regime(self):
+        """get_macro_regime() includes dxy_status field from _fetch_dxy()."""
+        # Reset caches
+        mr._macro_cache = None
+        mr._macro_cache_ts = 0.0
+        mr._vix_cache = None
+        mr._vix_cache_ts = 0.0
+        mr._dxy_cache = None
+        mr._dxy_cache_ts = 0.0
+
+        def mock_ticker(symbol):
+            t = MagicMock()
+            if symbol in ("DX-Y.NYB", "UUP"):
+                t.history.return_value = _empty_hist()
+            else:
+                t.history.return_value = _empty_hist()
+            return t
+
+        with patch("yfinance.Ticker", side_effect=mock_ticker):
+            regime = mr.get_macro_regime()
+
+        self.assertIn("dxy_status", regime)
+        # With both failing, must be unavailable — not "live" or absent
+        self.assertEqual(regime["dxy_status"], "unavailable")
+        # dxy must not be a fake zero
+        self.assertIsNone(regime.get("dxy"))
+
+    def test_dxy_change_pct_computed_correctly(self):
+        """Change percent is computed as (current - prev) / prev * 100."""
+        call_count = {"n": 0}
+        import pandas as pd
+
+        def mock_ticker(symbol):
+            t = MagicMock()
+            if symbol == "DX-Y.NYB":
+                t.history.return_value = pd.DataFrame({"Close": [100.0, 101.0]})
+            return t
+
+        with patch("yfinance.Ticker", side_effect=mock_ticker):
+            result = mr._fetch_dxy()
+
+        self.assertEqual(result["dxy_status"], "live")
+        self.assertAlmostEqual(result["dxy_change_pct"], 1.0, places=2)
+
+
+class TestDxyTTL(unittest.TestCase):
+    """DXY cache respects TTL and returns fresh data after expiry."""
+
+    def setUp(self):
+        mr._dxy_cache = None
+        mr._dxy_cache_ts = 0.0
+
+    def test_cache_is_reused_within_ttl(self):
+        """Second call within TTL does not re-fetch."""
+        mock_ticker = MagicMock()
+        mock_ticker.history.return_value = _make_hist(104.5)
+
+        with patch("yfinance.Ticker", return_value=mock_ticker):
+            r1 = mr._fetch_dxy()
+            r2 = mr._fetch_dxy()
+
+        # Ticker.history should only be called once (first fetch)
+        self.assertEqual(mock_ticker.history.call_count, 1)
+        self.assertEqual(r1["dxy_status"], r2["dxy_status"])
+
+    def test_cache_refreshes_after_expiry(self):
+        """After TTL expires, a new fetch is performed."""
+        mock_ticker = MagicMock()
+        mock_ticker.history.return_value = _make_hist(104.5)
+
+        with patch("yfinance.Ticker", return_value=mock_ticker):
+            mr._fetch_dxy()
+            # Artificially expire the cache
+            mr._dxy_cache_ts = time.time() - 10000
+            mr._fetch_dxy()
+
+        self.assertGreaterEqual(mock_ticker.history.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tcode/alpha_engine/tests/test_premarket.py
+++ b/tcode/alpha_engine/tests/test_premarket.py
@@ -29,12 +29,23 @@ class TestPremarketStructure(unittest.TestCase):
         """
         Patch yfinance so each Ticker(symbol).history() returns the configured DataFrame.
         ticker_map: {symbol: [close_prev, close_now]}
+
+        Phase 13.5: DXY key changed from "^DXY" to "DX-Y.NYB" (primary source).
+        Tests using "^DXY" are automatically remapped to "DX-Y.NYB".
         """
         import pandas as pd
 
+        # Remap legacy ^DXY test keys to new primary source
+        remapped: dict = {}
+        for k, v in ticker_map.items():
+            if k == "^DXY":
+                remapped["DX-Y.NYB"] = v  # primary source
+            else:
+                remapped[k] = v
+
         def mock_ticker(symbol):
             t = MagicMock()
-            closes = ticker_map.get(symbol, [100.0, 100.0])
+            closes = remapped.get(symbol, [100.0, 100.0])
             hist = _make_hist(closes)
 
             def history(period="2d", prepost=False):
@@ -46,9 +57,12 @@ class TestPremarketStructure(unittest.TestCase):
             return t
 
         with patch("yfinance.Ticker", side_effect=mock_ticker):
-            # Force cache miss so _fetch_premarket() runs
+            # Force cache misses so _fetch_premarket() and _fetch_dxy() both run
             import ingestion.premarket as pm
+            import ingestion.macro_regime as mr
             pm._premarket_cache = None
+            mr._dxy_cache = None
+            mr._dxy_cache_ts = 0.0
             result = pm._fetch_premarket()
         return result
 

--- a/tcode/alpha_engine/tests/test_underlying_stop_qualification.py
+++ b/tcode/alpha_engine/tests/test_underlying_stop_qualification.py
@@ -1,0 +1,257 @@
+"""
+Tests for Phase 13.5: Underlying-stop contract qualification fix (ibkr_order.py).
+
+Covers:
+  - classify_ibkr_error() classifies Error 321 as 'fatal'
+  - classify_ibkr_error() classifies transient errors correctly
+  - place_bracket_order() calls reqContractDetails() instead of qualifyContracts()
+    for the underlying contract
+  - When reqContractDetails() returns empty details, bracket downgrades gracefully
+    (SL uses option-premium stop, [BRACKET-DOWNGRADE] logged)
+  - When reqContractDetails() returns conId=0, also downgrades
+  - When reqContractDetails() returns valid conId, PriceCondition is built with it
+
+Note: Integration tests against a live IBKR Gateway are in a separate file
+      and are marked @pytest.mark.integration.
+"""
+import sys
+import json
+import unittest
+from unittest.mock import patch, MagicMock, call
+
+sys.path.insert(0, "/home/builder/src/gpfiles/tcode/alpha_engine")
+
+from ingestion.ibkr_order import classify_ibkr_error
+
+
+class TestClassifyIbkrError(unittest.TestCase):
+    """Error classifier must correctly identify fatal vs transient IBKR errors."""
+
+    def test_error_321_is_fatal(self):
+        """Error 321 (invalid contract id) is a configuration error — fatal, do not retry."""
+        self.assertEqual(classify_ibkr_error(321), "fatal")
+        self.assertEqual(classify_ibkr_error(321, "Error validating request"), "fatal")
+
+    def test_error_200_is_fatal(self):
+        """Error 200 (no security definition) is fatal — wrong contract params."""
+        self.assertEqual(classify_ibkr_error(200), "fatal")
+
+    def test_connectivity_errors_are_transient(self):
+        """Connectivity errors should be retried."""
+        self.assertEqual(classify_ibkr_error(1100), "transient")
+        self.assertEqual(classify_ibkr_error(504), "transient")
+
+    def test_unknown_error_code(self):
+        """Unknown error codes return 'unknown'."""
+        self.assertEqual(classify_ibkr_error(9999), "unknown")
+        self.assertEqual(classify_ibkr_error(0), "unknown")
+
+    def test_message_parameter_does_not_change_classification(self):
+        """Classification is based on error code, not message text."""
+        self.assertEqual(classify_ibkr_error(321, "some random message"), "fatal")
+        self.assertEqual(classify_ibkr_error(1100, "some random message"), "transient")
+
+
+class TestBracketOrderQualification(unittest.TestCase):
+    """
+    place_bracket_order() must use reqContractDetails() for underlying
+    contract qualification, not qualifyContracts().
+    """
+
+    def _make_ib_mock(self, con_id: int = 12345, details_empty: bool = False):
+        """
+        Build a minimal IB mock for testing place_bracket_order.
+
+        Args:
+            con_id: conId to return from reqContractDetails
+            details_empty: if True, return empty list from reqContractDetails
+        """
+        ib = MagicMock()
+
+        # Option contract qualification succeeds
+        opt_contract = MagicMock()
+        opt_contract.conId = 99999
+        ib.qualifyContracts.return_value = [opt_contract]
+
+        # reqContractDetails for underlying
+        if details_empty:
+            ib.reqContractDetails.return_value = []
+        else:
+            detail = MagicMock()
+            detail.contract = MagicMock()
+            detail.contract.conId = con_id
+            ib.reqContractDetails.return_value = [detail]
+
+        # bracketOrder returns 3 mock orders
+        parent = MagicMock()
+        parent.orderType = "LMT"
+        tp = MagicMock()
+        tp.orderType = "LMT"
+        sl = MagicMock()
+        sl.orderType = "STP LMT"
+        sl.conditions = []
+        sl.auxPrice = 0.14
+        sl.lmtPrice = 0.126
+        ib.bracketOrder.return_value = [parent, tp, sl]
+
+        # placeOrder returns trade mocks
+        def _make_trade(order):
+            t = MagicMock()
+            t.order = order
+            t.order.orderId = 100 + id(order) % 1000
+            t.order.ocaGroup = "OCA_1"
+            t.orderStatus.status = "Submitted"
+            return t
+
+        ib.placeOrder.side_effect = lambda contract, order: _make_trade(order)
+        ib.sleep.return_value = None
+
+        return ib
+
+    def _call_place_bracket(self, ib_mock, underlying_stop: str = "TSLA:340.0"):
+        """Call place_bracket_order with a test bracket including --underlying-stop."""
+        from unittest.mock import patch as _patch
+
+        # Patch the connect/disconnect helpers and ib_insync classes
+        with _patch("ingestion.ibkr_order._connect", return_value=ib_mock), \
+             _patch("ingestion.ibkr_order._disconnect"), \
+             _patch("ingestion.ibkr_order.place_bracket_order.__code__",
+                    wraps=None, create=True) as _unused:
+            from ingestion.ibkr_order import place_bracket_order
+            return place_bracket_order(
+                host="127.0.0.1",
+                port=7497,
+                client_id=3,
+                symbol="TSLA",
+                contract_type="CALL",
+                strike=365.0,
+                expiry="2026-04-18",
+                action="BUY",
+                quantity=10,
+                limit_price=0.28,
+                take_profit_price=0.56,
+                stop_loss_price=0.14,
+                underlying_stop_symbol="TSLA",
+                underlying_stop_price=340.0,
+            )
+
+    def test_req_contract_details_called_for_underlying(self):
+        """reqContractDetails() must be called when underlying_stop_symbol is provided."""
+        ib = self._make_ib_mock(con_id=76792991)
+
+        with patch("ingestion.ibkr_order._connect", return_value=ib), \
+             patch("ingestion.ibkr_order._disconnect"):
+            from ingestion.ibkr_order import place_bracket_order
+            place_bracket_order(
+                host="127.0.0.1", port=7497, client_id=3,
+                symbol="TSLA", contract_type="CALL", strike=365.0,
+                expiry="2026-04-18", action="BUY", quantity=10,
+                limit_price=0.28, take_profit_price=0.56, stop_loss_price=0.14,
+                underlying_stop_symbol="TSLA", underlying_stop_price=340.0,
+            )
+
+        ib.reqContractDetails.assert_called_once()
+
+    def test_empty_details_downgrades_bracket(self):
+        """
+        When reqContractDetails returns empty list, PriceCondition is NOT applied
+        and a [BRACKET-DOWNGRADE] warning is logged.
+        """
+        ib = self._make_ib_mock(details_empty=True)
+
+        import logging
+        with patch("ingestion.ibkr_order._connect", return_value=ib), \
+             patch("ingestion.ibkr_order._disconnect"), \
+             self.assertLogs("ibkr_order", level="WARNING") as log_ctx:
+            from ingestion.ibkr_order import place_bracket_order
+            place_bracket_order(
+                host="127.0.0.1", port=7497, client_id=3,
+                symbol="TSLA", contract_type="CALL", strike=365.0,
+                expiry="2026-04-18", action="BUY", quantity=10,
+                limit_price=0.28, take_profit_price=0.56, stop_loss_price=0.14,
+                underlying_stop_symbol="TSLA", underlying_stop_price=340.0,
+            )
+
+        # Check [BRACKET-DOWNGRADE] is in log output
+        log_text = " ".join(log_ctx.output)
+        self.assertIn("BRACKET-DOWNGRADE", log_text)
+
+        # SL leg conditions must be empty (no PriceCondition attached)
+        sl_order = ib.bracketOrder.return_value[2]
+        self.assertEqual(sl_order.conditions, [])
+
+    def test_zero_con_id_downgrades_bracket(self):
+        """
+        When reqContractDetails returns conId=0, PriceCondition is NOT applied.
+        This is the exact scenario that caused Error 321 in Phase 9.
+        """
+        ib = self._make_ib_mock(con_id=0)
+
+        with patch("ingestion.ibkr_order._connect", return_value=ib), \
+             patch("ingestion.ibkr_order._disconnect"), \
+             self.assertLogs("ibkr_order", level="WARNING") as log_ctx:
+            from ingestion.ibkr_order import place_bracket_order
+            place_bracket_order(
+                host="127.0.0.1", port=7497, client_id=3,
+                symbol="TSLA", contract_type="CALL", strike=365.0,
+                expiry="2026-04-18", action="BUY", quantity=10,
+                limit_price=0.28, take_profit_price=0.56, stop_loss_price=0.14,
+                underlying_stop_symbol="TSLA", underlying_stop_price=340.0,
+            )
+
+        log_text = " ".join(log_ctx.output)
+        self.assertIn("BRACKET-DOWNGRADE", log_text)
+
+    def test_valid_con_id_builds_price_condition(self):
+        """
+        When reqContractDetails returns conId > 0, PriceCondition is built
+        with that conId (not 0).
+        """
+        ib = self._make_ib_mock(con_id=76792991)
+        conditions_assigned = []
+
+        original_sl = ib.bracketOrder.return_value[2]
+
+        def capture_conditions(cond_list):
+            conditions_assigned.extend(cond_list)
+
+        type(original_sl).conditions = property(
+            fget=lambda self: [],
+            fset=lambda self, val: conditions_assigned.extend(val),
+        )
+
+        with patch("ingestion.ibkr_order._connect", return_value=ib), \
+             patch("ingestion.ibkr_order._disconnect"):
+            from ingestion.ibkr_order import place_bracket_order
+            place_bracket_order(
+                host="127.0.0.1", port=7497, client_id=3,
+                symbol="TSLA", contract_type="CALL", strike=365.0,
+                expiry="2026-04-18", action="BUY", quantity=10,
+                limit_price=0.28, take_profit_price=0.56, stop_loss_price=0.14,
+                underlying_stop_symbol="TSLA", underlying_stop_price=340.0,
+            )
+
+        # reqContractDetails must have been called (not just qualifyContracts)
+        ib.reqContractDetails.assert_called_once()
+
+    def test_no_underlying_stop_skips_req_contract_details(self):
+        """When no --underlying-stop is provided, reqContractDetails is not called."""
+        ib = self._make_ib_mock(con_id=76792991)
+
+        with patch("ingestion.ibkr_order._connect", return_value=ib), \
+             patch("ingestion.ibkr_order._disconnect"):
+            from ingestion.ibkr_order import place_bracket_order
+            place_bracket_order(
+                host="127.0.0.1", port=7497, client_id=3,
+                symbol="TSLA", contract_type="CALL", strike=365.0,
+                expiry="2026-04-18", action="BUY", quantity=10,
+                limit_price=0.28, take_profit_price=0.56, stop_loss_price=0.14,
+                underlying_stop_symbol="",  # empty = no underlying stop
+                underlying_stop_price=0.0,
+            )
+
+        ib.reqContractDetails.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Stabilization Phase 13.5 — data-source repairs + IBKR contract qualification

Target repo: franksbaz/gpfiles  
Head: mmucklo:fix/stabilization-phase-13-5-data-source-repairs  
Base: master

---

## Summary

Four targeted fixes for live errors observed in publisher.service.log:

**1. Fix `^DXY` delisted from yfinance (`macro_regime.py`, `premarket.py`)**
- Adds `_fetch_dxy()` with `DX-Y.NYB` (ICE futures) as primary, `UUP` ETF as proxy fallback
- Returns `dxy_status: "live" | "uup_proxy" | "unavailable"` — never substitutes stale zeros
- Cache: 5min during US hours, 15min off-hours
- Pre-Market Panel FX row shows green/amber/red source badge with `TermLabel` tooltips

**2. Senate eFTS retry + circuit-break (`congress_trades.py`)**
- 3 retry attempts with exponential backoff (1s, 4s, 16s) before circuit opens
- Circuit stays open 10 minutes; logs `[CONGRESS-DEGRADED] reason=… next_retry_at=…`
- `/api/intel` congress sub-object now includes `senate: {status, last_success_at, last_error}` and `house: {...}`
- Congress card UI: amber subtitle "Senate feed degraded — retrying at HH:MM"; red both-down state

**3. House PTR 2026 URL — documented disabled (`congress_trades.py`)**
- Investigated: `ptr-pdfs/2026FD.xml` → 404; `financial-pdfs/2026FD.zip` → 200 but XML is a filing index only (no per-ticker `<Asset>/<TransactionType>` data)
- Feed disabled with explicit warning log and `TODO(phase-13.5)` comment
- UI shows "House feed: annual discovery required" with tooltip
- `HOUSE_PTR_URL_PATTERN` constant documents new ZIP pattern for next annual update

**4. IBKR Error 321 — contract qualification fix (`ibkr_order.py`)**
- Replaces `qualifyContracts()` with `reqContractDetails()` for underlying contract; verifies `conId > 0` before `PriceCondition`
- Failed qualification: logs `[CONTRACT-QUAL-FAIL]` + `[BRACKET-DOWNGRADE]`, falls back to option-premium SL
- `classify_ibkr_error(321)` → `"fatal"` (not retried); `classify_ibkr_error(1100)` → `"transient"`

**5. Glossary + UX gate**
- 5 new `term_glossary.ts` entries: `DXY_SOURCE`, `UUP_PROXY`, `SOURCE_DEGRADED`, `PRICE_CONDITION`, `IBKR_ERROR_321`
- Fixed `ux_integrity_contract.spec.ts`: changed `networkidle` → `load` (polling SPA never reaches networkidle)

## Commits

- `fix(macro)`: replace delisted ^DXY with DX-Y.NYB primary, UUP proxy fallback, source badge
- `fix(congress)`: retry + circuit-break Senate eFTS; surface degraded status in /api/intel
- `fix(ibkr)`: qualify TSLA contract via reqContractDetails before PriceCondition; classify Error 321 as fatal
- `feat(ui)`: source badges + degraded state on Pre-Market and Congress cards
- `test`: dxy fallback, congress degraded path, underlying-stop qualification
- `fix(ux-gate)`: change networkidle → load in integrity dashboard test

## Test results

```
351 passed, 4 skipped (pre-existing IBKR live-gateway tests), 0 new failures
31 new tests: test_dxy_fallback.py (9), test_congress_degraded.py (12), test_underlying_stop_qualification.py (10)
UX gate: 4 passed, 1 skipped (off-hours/amber — expected)
TypeScript: clean compile (tsc -b + vite build)
```

## House PTR investigation note

The old `ptr-pdfs/{year}FD.xml` URL returns 404. The new ZIP at `financial-pdfs/{year}FD.zip` exists (verified 200, 10KB, last-modified 2026-04-13) but contains only a filing index — member names + DocIDs, no `<Asset>` or `<TransactionType>` fields. Per-transaction data requires parsing individual PDF disclosures via DocID. Feed is disabled pending a transaction-level source; Senate-only signal still functions normally.

## Verification pending (live environment, 2026-04-14 13:30-14:00 UTC)

- [ ] publisher.service.log 30-min clean window (zero of the 5 original errors)
- [ ] `curl http://localhost:2112/api/intel | jq '.macro_regime.dxy, .congress'`
- [ ] Pre-Market Panel screenshot (DXY source badge, 1440px)
- [ ] Congress card screenshot (Senate degraded state — mock eFTS to 503)
- [ ] IBKR paper bracket with `--underlying-stop` — no Error 321, `ib.openOrders()` dump

🤖 Generated with [Claude Code](https://claude.com/claude-code)
