### PR TITLE
Stabilization Phase 13.6 — publisher heartbeat + system health panel

### DIFF
--- a/tcode/alpha_control_center/src/App.tsx
+++ b/tcode/alpha_control_center/src/App.tsx
@@ -5,6 +5,7 @@ import './components/Tooltip.css';
 import Tooltip from './components/Tooltip';
 import IntegrityStatus from './components/IntegrityStatus';
 import HelpPanel from './components/HelpPanel';
+import { SystemHealthBadge, type HealthSummary } from './components/SystemHealthPanel';
 import { Shield, Menu, Home, Share2, Map, HelpCircle } from 'lucide-react';
 import Dashboard from './pages/Dashboard';
 import Architecture from './pages/Architecture';
@@ -23,6 +24,7 @@ function App() {
   const [showSettings, setShowSettings] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [integrityRed, setIntegrityRed] = useState(false);
+  const [healthSummary, setHealthSummary] = useState<HealthSummary | null>(null);
 
   // Notional account size state
   const [notional, setNotional] = useState<number>(25000);
@@ -321,6 +323,11 @@ function App() {
             {/* Integrity Status — three traffic lights */}
             <IntegrityStatus onStatusChange={handleIntegrityChange} />
 
+            {/* System health badge — Phase 13.6: always visible, goes red on component outage */}
+            <SystemHealthBadge
+              summary={healthSummary}
+            />
+
             {/* Execution mode banner — always visible, never hidden.
                 Maps the EXECUTION_MODE enum (IBKR_PAPER / IBKR_LIVE / SIMULATION)
                 to colour-coded labels with a disconnected warning overlay. */}
@@ -409,7 +416,7 @@ function App() {
 
       <main className="main-content" role="main">
         <Routes>
-          <Route path="/" element={<Dashboard brokerStatus={brokerStatus} integrityRed={integrityRed} />} />
+          <Route path="/" element={<Dashboard brokerStatus={brokerStatus} integrityRed={integrityRed} onHealthChange={setHealthSummary} />} />
           <Route path="/architecture" element={<Architecture />} />
           <Route path="/gastown" element={<Gastown />} />
         </Routes>

--- a/tcode/alpha_control_center/src/components/SystemHealthPanel.css
+++ b/tcode/alpha_control_center/src/components/SystemHealthPanel.css
@@ -1,0 +1,370 @@
+/* SystemHealthPanel — Phase 13.6 */
+
+/* ── Panel container ─────────────────────────────────────────────────────── */
+.sph-panel {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 8px;
+  padding: 0;
+  overflow: hidden;
+}
+
+.sph-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px 8px;
+  border-bottom: 1px solid #21262d;
+}
+
+.sph-panel-title {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #8b949e;
+  text-transform: uppercase;
+}
+
+.sph-loading {
+  font-size: 10px;
+  color: #6e7681;
+}
+
+/* ── Component grid ───────────────────────────────────────────────────────── */
+.sph-grid {
+  display: flex;
+  flex-direction: column;
+}
+
+.sph-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 14px;
+  border: none;
+  background: transparent;
+  color: #c9d1d9;
+  cursor: pointer;
+  text-align: left;
+  font-size: 12px;
+  transition: background 0.15s;
+  border-bottom: 1px solid #21262d;
+}
+
+.sph-row:last-child {
+  border-bottom: none;
+}
+
+.sph-row:hover {
+  background: rgba(56, 68, 77, 0.4);
+}
+
+.sph-row-error {
+  background: rgba(248, 81, 73, 0.06);
+}
+
+.sph-row-error:hover {
+  background: rgba(248, 81, 73, 0.12);
+}
+
+.sph-row-degraded {
+  background: rgba(210, 153, 34, 0.06);
+}
+
+/* ── LED indicator ────────────────────────────────────────────────────────── */
+.sph-led {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  box-shadow: 0 0 3px currentColor;
+}
+
+.sph-pulse {
+  animation: sph-led-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes sph-led-pulse {
+  0%, 100% { opacity: 1; box-shadow: 0 0 4px #f85149; }
+  50% { opacity: 0.45; box-shadow: 0 0 12px #f85149; }
+}
+
+/* ── Row fields ───────────────────────────────────────────────────────────── */
+.sph-comp-name {
+  flex: 1;
+  font-weight: 500;
+}
+
+.sph-age {
+  font-size: 11px;
+  color: #8b949e;
+  min-width: 60px;
+  text-align: right;
+}
+
+.sph-cadence {
+  font-size: 10px;
+  color: #6e7681;
+  min-width: 70px;
+  text-align: right;
+}
+
+/* ── Header badge ─────────────────────────────────────────────────────────── */
+.sph-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-weight: 700;
+  cursor: pointer;
+  letter-spacing: 0.03em;
+  color: #fff;
+  white-space: nowrap;
+  transition: opacity 0.2s;
+}
+
+.sph-badge:hover {
+  opacity: 0.85;
+}
+
+.sph-badge-pulse {
+  animation: sph-badge-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes sph-badge-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}
+
+/* ── Drill-down overlay ───────────────────────────────────────────────────── */
+.sph-drill-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 9000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sph-drill-card {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 20px 22px;
+  min-width: 360px;
+  max-width: 520px;
+  width: 100%;
+  max-height: 85vh;
+  overflow-y: auto;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+}
+
+.sph-drill-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.sph-drill-title {
+  flex: 1;
+  font-size: 14px;
+  font-weight: 700;
+  color: #e6edf3;
+}
+
+.sph-drill-close {
+  background: none;
+  border: none;
+  color: #8b949e;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 0 4px;
+}
+
+.sph-drill-close:hover { color: #c9d1d9; }
+
+/* ── Drill-down table ─────────────────────────────────────────────────────── */
+.sph-drill-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+  margin-bottom: 14px;
+}
+
+.sph-drill-table td {
+  padding: 5px 8px;
+  border-bottom: 1px solid #21262d;
+  color: #c9d1d9;
+}
+
+.sph-drill-table td:first-child {
+  color: #8b949e;
+  white-space: nowrap;
+  width: 40%;
+}
+
+.sph-status-badge {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.sph-status-ok     { background: rgba(63,185,80,0.2); color: #3fb950; }
+.sph-status-degraded { background: rgba(210,153,34,0.2); color: #d29922; }
+.sph-status-error  { background: rgba(248,81,73,0.2); color: #f85149; }
+
+.sph-na { color: #6e7681; font-style: italic; }
+
+/* ── Sparkline ────────────────────────────────────────────────────────────── */
+.sph-sparkline-label {
+  font-size: 10px;
+  color: #6e7681;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.sph-sparkline {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.sph-spark-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+}
+
+.sph-spark-ts {
+  color: #8b949e;
+  font-family: monospace;
+  min-width: 58px;
+}
+
+.sph-spark-detail {
+  color: #6e7681;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sph-sparkline-empty {
+  font-size: 11px;
+  color: #6e7681;
+  font-style: italic;
+  padding: 8px 0;
+}
+
+/* ── Restart button ───────────────────────────────────────────────────────── */
+.sph-btn-restart {
+  background: #21262d;
+  border: 1px solid #30363d;
+  color: #c9d1d9;
+  border-radius: 6px;
+  padding: 6px 14px;
+  font-size: 12px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background 0.15s;
+}
+
+.sph-btn-restart:hover {
+  background: #2d333b;
+  border-color: #8b949e;
+}
+
+/* ── Toast ────────────────────────────────────────────────────────────────── */
+.sph-toast {
+  margin-top: 10px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.sph-toast-ok  { background: rgba(63,185,80,0.2); color: #3fb950; }
+.sph-toast-err { background: rgba(248,81,73,0.2); color: #f85149; }
+
+/* ── Restart confirmation modal ───────────────────────────────────────────── */
+.sph-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sph-modal-card {
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 24px 28px;
+  min-width: 320px;
+  max-width: 440px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.7);
+}
+
+.sph-modal-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: #e6edf3;
+  margin-bottom: 10px;
+}
+
+.sph-modal-body {
+  font-size: 13px;
+  color: #8b949e;
+  line-height: 1.5;
+  margin: 0 0 4px;
+}
+
+.sph-modal-body code {
+  background: #21262d;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 11px;
+  color: #79c0ff;
+}
+
+.sph-btn-cancel {
+  background: #21262d;
+  border: 1px solid #30363d;
+  color: #c9d1d9;
+  border-radius: 6px;
+  padding: 6px 14px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.sph-btn-cancel:hover { background: #2d333b; }
+
+.sph-btn-confirm {
+  background: #6e1919;
+  border: 1px solid #f85149;
+  color: #fff;
+  border-radius: 6px;
+  padding: 6px 18px;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s;
+}
+
+.sph-btn-confirm:disabled {
+  background: #30363d;
+  border-color: #484f58;
+  color: #6e7681;
+  cursor: not-allowed;
+}
+
+.sph-btn-confirm:not(:disabled):hover { background: #8b2020; }

--- a/tcode/alpha_control_center/src/components/SystemHealthPanel.tsx
+++ b/tcode/alpha_control_center/src/components/SystemHealthPanel.tsx
@@ -1,0 +1,467 @@
+/**
+ * SystemHealthPanel — Phase 13.6
+ *
+ * Displays a grid of LED indicators for every long-running platform component.
+ * Each row shows: LED · component name (TermLabel) · last heartbeat age · expected cadence.
+ * Clicking a row opens a drill-down popover with sparkline + restart button.
+ *
+ * Also exports <SystemHealthBadge /> for the dashboard header.
+ */
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import TermLabel from './TermLabel';
+import './SystemHealthPanel.css';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type HeartbeatStatus = 'ok' | 'degraded' | 'error';
+
+export interface ComponentHealth {
+  status: HeartbeatStatus;
+  last_ts: string | null;
+  age_sec: number | null;
+  expected_max_age_sec: number;
+  pid: number | null;
+  uptime_sec: number | null;
+  detail: string | null;
+}
+
+export interface HeartbeatsPayload {
+  ts: string;
+  components: Record<string, ComponentHealth>;
+}
+
+interface SparklineRow {
+  ts: string;
+  status: string;
+  detail: string | null;
+  pid: number | null;
+  uptime_sec: number | null;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function fmtAge(ageSec: number | null): string {
+  if (ageSec === null || ageSec === undefined) return 'never';
+  if (ageSec < 60) return `${Math.round(ageSec)}s ago`;
+  if (ageSec < 3600) return `${Math.round(ageSec / 60)}m ago`;
+  return `${Math.round(ageSec / 3600)}h ago`;
+}
+
+function fmtUptime(uptimeSec: number | null): string {
+  if (!uptimeSec) return '—';
+  const h = Math.floor(uptimeSec / 3600);
+  const m = Math.floor((uptimeSec % 3600) / 60);
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+const LED_COLOR: Record<HeartbeatStatus, string> = {
+  ok: '#3fb950',
+  degraded: '#d29922',
+  error: '#f85149',
+};
+
+// Maps component key → glossary term key
+const COMPONENT_TERM: Record<string, string> = {
+  publisher: 'PUBLISHER',
+  intel_refresh: 'INTEL_REFRESH',
+  options_chain_api: 'OPTIONS_CHAIN_API',
+  premarket: 'PREMARKET',
+  congress_trades: 'CONGRESS_TRADES',
+  correlation_regime: 'CORRELATION_REGIME',
+  macro_regime: 'MACRO_REGIME',
+  engine_subscriber: 'ENGINE_SUBSCRIBER',
+  engine_ibkr_status: 'IBKR_GATEWAY',
+};
+
+// ── Sparkline ─────────────────────────────────────────────────────────────────
+
+const StatusDot = ({ status }: { status: string }) => {
+  const color = status === 'ok' ? '#3fb950' : status === 'degraded' ? '#d29922' : '#f85149';
+  return (
+    <span
+      style={{
+        display: 'inline-block',
+        width: 10,
+        height: 10,
+        borderRadius: '50%',
+        backgroundColor: color,
+        flexShrink: 0,
+      }}
+      title={status}
+      aria-label={`status: ${status}`}
+    />
+  );
+};
+
+const Sparkline = ({ rows }: { rows: SparklineRow[] }) => {
+  if (!rows.length) return <div className="sph-sparkline-empty">No heartbeat history</div>;
+  return (
+    <div className="sph-sparkline" aria-label="Last 10 heartbeats">
+      {[...rows].reverse().map((r, i) => (
+        <div key={i} className="sph-spark-row" title={r.detail ?? r.status}>
+          <StatusDot status={r.status} />
+          <span className="sph-spark-ts">{r.ts.slice(11, 19)}</span>
+          {r.detail && (
+            <span className="sph-spark-detail">{r.detail.slice(0, 48)}</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+// ── Restart Button + 3s countdown modal ───────────────────────────────────────
+
+interface RestartModalProps {
+  component: string;
+  onClose: () => void;
+  onSuccess: (msg: string) => void;
+  onError: (msg: string) => void;
+}
+
+const RestartModal = ({ component, onClose, onSuccess, onError }: RestartModalProps) => {
+  const [countdown, setCountdown] = useState(3);
+  const [restarting, setRestarting] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    timerRef.current = setInterval(() => {
+      setCountdown(n => {
+        if (n <= 1) {
+          if (timerRef.current) clearInterval(timerRef.current);
+          return 0;
+        }
+        return n - 1;
+      });
+    }, 1000);
+    return () => { if (timerRef.current) clearInterval(timerRef.current); };
+  }, []);
+
+  const handleConfirm = async () => {
+    if (countdown > 0 || restarting) return;
+    setRestarting(true);
+    try {
+      const res = await fetch(`/api/system/heartbeats/${component}/restart`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      const data = await res.json();
+      if (data.ok) {
+        onSuccess(data.msg ?? `Restarted ${component}`);
+      } else {
+        onError(data.error ?? 'restart failed');
+      }
+    } catch (e: unknown) {
+      onError(e instanceof Error ? e.message : 'network error');
+    }
+    setRestarting(false);
+    onClose();
+  };
+
+  return createPortal(
+    <div className="sph-modal-overlay" onClick={onClose} role="dialog" aria-modal="true"
+      aria-label={`Confirm restart ${component}`}>
+      <div className="sph-modal-card" onClick={e => e.stopPropagation()}>
+        <div className="sph-modal-title">Restart {component}?</div>
+        <p className="sph-modal-body">
+          This will run <code>systemctl --user restart</code> for the associated service.
+          The component will be offline for a few seconds.
+        </p>
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end', marginTop: 16 }}>
+          <button className="sph-btn-cancel" onClick={onClose}>Cancel</button>
+          <button
+            className="sph-btn-confirm"
+            onClick={handleConfirm}
+            disabled={countdown > 0 || restarting}
+            data-testid="restart-confirm-btn"
+          >
+            {restarting ? 'Restarting…' : countdown > 0 ? `Restart (${countdown})` : 'Restart'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+};
+
+// ── DrillDown popover ─────────────────────────────────────────────────────────
+
+const RESTARTABLE = new Set(['publisher', 'engine_subscriber', 'engine_ibkr_status']);
+
+interface DrillDownProps {
+  component: string;
+  health: ComponentHealth;
+  onClose: () => void;
+}
+
+const DrillDown = ({ component, health, onClose }: DrillDownProps) => {
+  const [sparkline, setSparkline] = useState<SparklineRow[]>([]);
+  const [sparkLoading, setSparkLoading] = useState(true);
+  const [restartModal, setRestartModal] = useState(false);
+  const [toast, setToast] = useState<{ msg: string; ok: boolean } | null>(null);
+
+  useEffect(() => {
+    setSparkLoading(true);
+    fetch(`/api/system/heartbeats/${component}/sparkline`)
+      .then(r => r.ok ? r.json() : [])
+      .then(data => { setSparkline(data); setSparkLoading(false); })
+      .catch(() => setSparkLoading(false));
+  }, [component]);
+
+  const ledColor = LED_COLOR[health.status];
+
+  return createPortal(
+    <div className="sph-drill-overlay" onClick={onClose} role="dialog" aria-modal="true"
+      aria-label={`${component} heartbeat detail`}>
+      <div className="sph-drill-card" onClick={e => e.stopPropagation()}>
+        <div className="sph-drill-header">
+          <span
+            className={`sph-led sph-led-${health.status}${health.status === 'error' ? ' sph-pulse' : ''}`}
+            style={{ backgroundColor: ledColor }}
+            aria-label={`status: ${health.status}`}
+          />
+          <span className="sph-drill-title">
+            <TermLabel term={COMPONENT_TERM[component] ?? component.toUpperCase()} />
+          </span>
+          <button className="sph-drill-close" onClick={onClose} aria-label="Close">✕</button>
+        </div>
+
+        <table className="sph-drill-table">
+          <tbody>
+            <tr>
+              <td>Status</td>
+              <td><span className={`sph-status-badge sph-status-${health.status}`}>{health.status.toUpperCase()}</span></td>
+            </tr>
+            <tr>
+              <td>Last heartbeat</td>
+              <td>{health.last_ts ?? <span className="sph-na">never</span>}</td>
+            </tr>
+            <tr>
+              <td>Age</td>
+              <td>{fmtAge(health.age_sec)}</td>
+            </tr>
+            <tr>
+              <td>Expected cadence</td>
+              <td>every {health.expected_max_age_sec}s</td>
+            </tr>
+            {health.pid != null && (
+              <tr>
+                <td>PID</td>
+                <td>{health.pid}</td>
+              </tr>
+            )}
+            {health.uptime_sec != null && (
+              <tr>
+                <td>Uptime</td>
+                <td>{fmtUptime(health.uptime_sec)}</td>
+              </tr>
+            )}
+            {health.detail && (
+              <tr>
+                <td>Last detail</td>
+                <td style={{ fontFamily: 'monospace', fontSize: 11 }}>{health.detail}</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+
+        <div className="sph-sparkline-label">Last 10 heartbeats</div>
+        {sparkLoading
+          ? <div className="sph-sparkline-empty">Loading…</div>
+          : <Sparkline rows={sparkline} />}
+
+        {RESTARTABLE.has(component) && (
+          <div style={{ marginTop: 12 }}>
+            <button
+              className="sph-btn-restart"
+              onClick={() => setRestartModal(true)}
+              data-testid="restart-service-btn"
+            >
+              Restart this service
+            </button>
+          </div>
+        )}
+
+        {toast && (
+          <div className={`sph-toast ${toast.ok ? 'sph-toast-ok' : 'sph-toast-err'}`}
+            role="alert">{toast.msg}</div>
+        )}
+      </div>
+
+      {restartModal && (
+        <RestartModal
+          component={component}
+          onClose={() => setRestartModal(false)}
+          onSuccess={msg => { setToast({ msg, ok: true }); setTimeout(() => setToast(null), 4000); }}
+          onError={msg => { setToast({ msg, ok: false }); setTimeout(() => setToast(null), 6000); }}
+        />
+      )}
+    </div>,
+    document.body,
+  );
+};
+
+// ── SystemHealthPanel ─────────────────────────────────────────────────────────
+
+const COMPONENT_ORDER = [
+  'publisher',
+  'intel_refresh',
+  'options_chain_api',
+  'premarket',
+  'congress_trades',
+  'correlation_regime',
+  'macro_regime',
+  'engine_subscriber',
+  'engine_ibkr_status',
+];
+
+export interface SystemHealthPanelProps {
+  onHealthChange?: (summary: { total: number; ok: number; degraded: number; error: number }) => void;
+}
+
+const SystemHealthPanel = ({ onHealthChange }: SystemHealthPanelProps) => {
+  const [data, setData] = useState<HeartbeatsPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [drillComponent, setDrillComponent] = useState<string | null>(null);
+
+  const fetchHeartbeats = useCallback(async () => {
+    try {
+      const res = await fetch('/api/system/heartbeats');
+      if (res.ok) {
+        const payload: HeartbeatsPayload = await res.json();
+        setData(payload);
+        setLoading(false);
+
+        // Notify parent of aggregate health
+        if (onHealthChange) {
+          const comps = Object.values(payload.components);
+          const total = comps.length;
+          const ok = comps.filter(c => c.status === 'ok').length;
+          const degraded = comps.filter(c => c.status === 'degraded').length;
+          const error = comps.filter(c => c.status === 'error').length;
+          onHealthChange({ total, ok, degraded, error });
+        }
+      }
+    } catch {
+      setLoading(false);
+    }
+  }, [onHealthChange]);
+
+  useEffect(() => {
+    fetchHeartbeats();
+    const id = setInterval(fetchHeartbeats, 15000);
+    return () => clearInterval(id);
+  }, [fetchHeartbeats]);
+
+  const components = data?.components ?? {};
+
+  return (
+    <div className="sph-panel" role="region" aria-label="System Health">
+      <div className="sph-panel-header">
+        <span className="sph-panel-title">
+          SYSTEM HEALTH
+        </span>
+        {loading && <span className="sph-loading">loading…</span>}
+      </div>
+
+      <div className="sph-grid" role="list">
+        {COMPONENT_ORDER.map(comp => {
+          const health = components[comp];
+          if (!health) return null;
+          const ledColor = LED_COLOR[health.status];
+          const termKey = COMPONENT_TERM[comp] ?? comp.toUpperCase();
+
+          return (
+            <button
+              key={comp}
+              role="listitem"
+              className={`sph-row sph-row-${health.status}`}
+              onClick={() => setDrillComponent(comp)}
+              aria-label={`${comp}: ${health.status}${health.age_sec != null ? `, ${fmtAge(health.age_sec)}` : ''}`}
+              data-testid={`sph-row-${comp}`}
+            >
+              <span
+                className={`sph-led sph-led-${health.status}${health.status === 'error' ? ' sph-pulse' : ''}`}
+                style={{ backgroundColor: ledColor }}
+                aria-hidden="true"
+              />
+              <span className="sph-comp-name">
+                <TermLabel term={termKey} />
+              </span>
+              <span className="sph-age">
+                {health.age_sec != null ? fmtAge(health.age_sec) : 'never'}
+              </span>
+              <span className="sph-cadence">
+                every {health.expected_max_age_sec}s
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {drillComponent && components[drillComponent] && (
+        <DrillDown
+          component={drillComponent}
+          health={components[drillComponent]}
+          onClose={() => setDrillComponent(null)}
+        />
+      )}
+    </div>
+  );
+};
+
+// ── SystemHealthBadge — always-visible header badge ───────────────────────────
+
+export interface HealthSummary {
+  total: number;
+  ok: number;
+  degraded: number;
+  error: number;
+}
+
+export interface SystemHealthBadgeProps {
+  summary: HealthSummary | null;
+  onClick?: () => void;
+}
+
+export const SystemHealthBadge = ({ summary, onClick }: SystemHealthBadgeProps) => {
+  if (!summary) return null;
+
+  const { total, ok, degraded, error } = summary;
+  const allOk = error === 0 && degraded === 0;
+  const anyError = error > 0;
+
+  let bg = '#1a7f37';
+  let border = '#3fb950';
+  let label = `SYS ${ok}/${total} ok`;
+  if (anyError) {
+    bg = '#6e1919';
+    border = '#f85149';
+    label = `SYS ⚠ ${error} error${error > 1 ? 's' : ''}`;
+  } else if (degraded > 0) {
+    bg = '#9e6a03';
+    border = '#d29922';
+    label = `SYS ${degraded} degraded`;
+  }
+
+  return (
+    <button
+      className={`sph-badge${anyError ? ' sph-badge-pulse' : ''}`}
+      style={{ background: bg, border: `1px solid ${border}` }}
+      onClick={onClick}
+      aria-label={`System health: ${label}`}
+      data-testid="system-health-badge"
+      title={allOk
+        ? `All ${total} components healthy`
+        : anyError
+        ? `${error} component${error > 1 ? 's' : ''} in ERROR state — click for details`
+        : `${degraded} component${degraded > 1 ? 's' : ''} degraded — click for details`}
+    >
+      {label}
+    </button>
+  );
+};
+
+export default SystemHealthPanel;

--- a/tcode/alpha_control_center/src/lib/term_glossary.ts
+++ b/tcode/alpha_control_center/src/lib/term_glossary.ts
@@ -803,6 +803,166 @@ Replaced with \`reqContractDetails()\`, which returns explicit contract details.
     related: ["PRICE_CONDITION"],
     phase_note: "Added in Phase 13.5.",
   },
+
+  // ── Phase 13.6 — System health / heartbeat terms ────────────────────────
+
+  HEARTBEAT: {
+    term: "HEARTBEAT",
+    display: "Heartbeat",
+    short: "A periodic liveness pulse emitted by each platform component — absence of a heartbeat means the process is dead or stuck.",
+    long: `**Heartbeat** is a lightweight row written to SQLite (and published to NATS \`system.heartbeat\`) after every operational cycle of a component.
+
+**Why heartbeats, not flags?**
+A startup flag set to \`connected = true\` stays true even if the process crashes. A heartbeat is fresh only if the process is actually executing. If the publisher dies (bad service unit path, OOM, permissions), heartbeats stop — the indicator goes amber within one cadence window, then red.
+
+**The 2026-04-13 incident:** publisher.service pointed at an abandoned path. Process exited 203/EXEC on every restart. Integrity dashboard showed engine/NATS/IBKR all green — because none measured publisher liveness. No signals generated all day. Phase 13.6 makes that failure impossible to miss.`,
+    formula: "ok: age ≤ expected_max; degraded: expected_max < age ≤ 3×; error: age > 3× or never seen",
+    source: "SQLite ~/tsla_alpha.db · NATS system.heartbeat",
+    trading_impact: "Publisher heartbeat RED = no signals. Other components affect data quality.",
+    related: ["PUBLISHER", "EXPECTED_CADENCE", "FLAPPING"],
+    phase_note: "Added in Phase 13.6.",
+  },
+
+  EXPECTED_CADENCE: {
+    term: "EXPECTED_CADENCE",
+    display: "Expected Cadence",
+    short: "The maximum healthy interval between heartbeats for a component — e.g. publisher: 30s, congress_trades: 3600s.",
+    long: `**Expected Cadence** is the maximum interval between heartbeats for each component when running normally.
+
+| Component | Max age (ok) |
+|---|---|
+| publisher | 30s |
+| intel_refresh | 300s |
+| options_chain_api | 120s |
+| premarket | 120s (4:00–9:30 ET only) |
+| congress_trades | 3600s |
+| correlation_regime | 3600s |
+| macro_regime | 300s |
+| engine_subscriber | 90s |
+| engine_ibkr_status | 180s |
+
+**Thresholds:** age ≤ max → ok; max < age ≤ 3× → degraded; age > 3× → error.
+
+**premarket off-hours exception:** outside 04:00–09:30 ET, premarket always shows ok with detail "skipped:off-hours".`,
+    formula: "ok: age ≤ max; degraded: max < age ≤ 3×max; error: age > 3×max",
+    trading_impact: "Stale intel_refresh or options_chain_api degrades signal quality. Publisher error = no new signals.",
+    related: ["HEARTBEAT", "FLAPPING"],
+    phase_note: "Added in Phase 13.6.",
+  },
+
+  FLAPPING: {
+    term: "FLAPPING",
+    display: "Flapping",
+    short: "A component that rapidly oscillates between ok and error/degraded — indicates an unstable process, not a clean outage.",
+    long: `**Flapping** occurs when a component repeatedly transitions between ok and error/degraded in a short window.
+
+**How to detect:** Open the drill-down popover for any component and look at the sparkline (last 10 heartbeats). A healthy component shows consistent green dots. A flapping component shows alternating colors.
+
+**Common causes:**
+- Rate limiting: the source API throttles, the component backs off, retries, gets throttled again.
+- OOM cycle: process killed and auto-restarted repeatedly.
+- Network instability: intermittent IBKR or NATS connectivity.
+- Cache TTL shorter than fetch latency: constant refetch failures.
+
+**vs. clean outage:** Clean outage = long run of red dots after a gap. Flapping = alternating pattern.`,
+    trading_impact: "Flapping components produce unreliable signals — confidence scores may reflect stale data despite occasional ok heartbeats.",
+    related: ["HEARTBEAT", "EXPECTED_CADENCE"],
+    phase_note: "Added in Phase 13.6.",
+  },
+
+  PUBLISHER: {
+    term: "PUBLISHER",
+    display: "Publisher",
+    short: "The Python process (publisher.py) that runs signal-generation models and broadcasts TSLA options signals to the Go execution engine via NATS.",
+    long: `**Publisher** is the Alpha Engine's primary signal-generation process (\`alpha_engine/publisher.py\`).
+
+**Responsibilities:** runs SENTIMENT, OPTIONS_FLOW, MACRO, VOLATILITY, CONTRARIAN, EV_SECTOR, PREMARKET models; applies data-quality gates; sizes positions via Kelly; publishes to NATS \`tsla.alpha.signals\`; emits heartbeat after every cycle.
+
+**Service unit:** \`publisher.service\`
+
+**The 2026-04-13 incident:** Unit file pointed at an abandoned path (\`/home/builder/src/gemini/...\`). Process exited 203/EXEC on every restart. No signals generated all day.`,
+    source: "alpha_engine/publisher.py · publisher.service",
+    trading_impact: "Publisher dead = zero signals = no new positions opened.",
+    related: ["HEARTBEAT", "EXPECTED_CADENCE"],
+    phase_note: "Added in Phase 13.6.",
+  },
+
+  INTEL_REFRESH: {
+    term: "INTEL_REFRESH",
+    display: "Intel Refresh",
+    short: "The intelligence aggregator (intel.py) that fetches news, VIX, SPY, options flow, macro, premarket, congress, and correlation data every 5 minutes.",
+    long: `**Intel Refresh** aggregates all external data sources into the \`intel\` dict consumed by signal models.
+
+**Sources:** news sentiment, VIX, SPY trend, earnings calendar, options flow (P/C ratio), catalyst (Musk + analysts), institutional flow, EV sector, macro regime, premarket, congress trades, correlation regime.
+
+**Cache TTL:** 5 minutes. Heartbeat emitted after each full fetch (not cache hits).`,
+    source: "alpha_engine/ingestion/intel.py",
+    trading_impact: "Stale intel = models operate on old data. Expected cadence: 300s.",
+    related: ["HEARTBEAT", "EXPECTED_CADENCE", "MACRO_REGIME"],
+    phase_note: "Added in Phase 13.6.",
+  },
+
+  OPTIONS_CHAIN_API: {
+    term: "OPTIONS_CHAIN_API",
+    display: "Options Chain API",
+    short: "The options chain cache that fetches TSLA strike/IV/OI data from yfinance or IBKR every 60s.",
+    long: `**Options Chain API** fetches and caches the TSLA options chain.
+
+**Source priority:** Off-hours + IBKR → IBKR snapshot; in-hours or IBKR unavailable → yfinance.
+
+**Cache TTL:** 60s. Heartbeat emitted on each fresh fetch.
+
+An empty or stale chain means the publisher cannot price strikes and will suppress signals.`,
+    source: "alpha_engine/ingestion/options_chain.py",
+    trading_impact: "Empty or stale chain = no priced strikes = no signals.",
+    related: ["HEARTBEAT", "EXPECTED_CADENCE"],
+    phase_note: "Added in Phase 13.6.",
+  },
+
+  ENGINE_SUBSCRIBER: {
+    term: "ENGINE_SUBSCRIBER",
+    display: "Engine Subscriber",
+    short: "The Go execution engine's NATS subscriber goroutine — listens on tsla.alpha.signals and routes signals to IBKR or simulation.",
+    long: `**Engine Subscriber** is the Go execution engine's primary signal-consumption loop (executor.service).
+
+Subscribes to \`tsla.alpha.signals\`; applies confidence gate (> 0.8), dedup, rank cap, gross-outstanding cap; routes to IBKR subprocess or PaperPortfolio.
+
+**Heartbeat:** 30s ticker goroutine writes to SQLite to prove the engine process is alive.`,
+    source: "execution_engine/subscriber.go · executor.service",
+    trading_impact: "Engine subscriber down = signals received but never executed.",
+    related: ["HEARTBEAT", "IBKR_GATEWAY"],
+    phase_note: "Added in Phase 13.6.",
+  },
+
+  IBKR_GATEWAY: {
+    term: "IBKR_GATEWAY",
+    display: "IBKR Gateway",
+    short: "IBKR API Gateway liveness — measured by whether open_orders() roundtrips succeed within the engine's 60s poll cycle.",
+    long: `**IBKR Gateway** tracks liveness of the connection to IBKR API Gateway (TWS or IB Gateway).
+
+A 60s ticker goroutine calls \`OpenIBKROrders()\` (shells \`ingestion/ibkr_order.py open_orders\`). Success → ok; failure → degraded + error detail stored.
+
+**Error codes to watch:** 1100 (connection lost), 1102 (connection restored after data loss).`,
+    source: "execution_engine/ibkr_client.go · ingestion/ibkr_order.py",
+    trading_impact: "IBKR gateway degraded = orders queue but cannot be submitted to broker.",
+    related: ["HEARTBEAT", "ENGINE_SUBSCRIBER"],
+    phase_note: "Added in Phase 13.6.",
+  },
+
+  NATS: {
+    term: "NATS",
+    display: "NATS",
+    short: "NATS messaging server (127.0.0.1:4222) — the pub/sub bus between the Python Alpha Engine and Go execution engine.",
+    long: `**NATS** is the lightweight pub/sub message broker connecting publisher to execution engine.
+
+**Subjects:** \`tsla.alpha.signals\` (signals), \`tsla.alpha.sim\` (mode toggle), \`system.heartbeat\` (liveness pulses, Phase 13.6).
+
+NATS runs 24/7 as a local process. If NATS goes down, the publisher retries connection on every cycle.`,
+    source: "nats-server (local) · github.com/nats-io/nats.go",
+    trading_impact: "NATS down = signals never reach execution engine = no order placement.",
+    related: ["PUBLISHER", "ENGINE_SUBSCRIBER", "HEARTBEAT"],
+    phase_note: "Added in Phase 13.6.",
+  },
 };
 
 /**

--- a/tcode/alpha_control_center/src/pages/Dashboard.tsx
+++ b/tcode/alpha_control_center/src/pages/Dashboard.tsx
@@ -6,6 +6,7 @@ import SystemMonitor from '../components/SystemMonitor';
 import { SkeletonCard, SkeletonTable } from '../components/SkeletonLoader';
 import { computeEconomics, formatRR, rrColorClass } from '../lib/signal_economics';
 import TermLabel from '../components/TermLabel';
+import SystemHealthPanel, { type HealthSummary } from '../components/SystemHealthPanel';
 
 // ============================================================
 //  Types
@@ -4649,7 +4650,7 @@ const CollapsiblePanel = ({
 //  Main Dashboard Component
 // ============================================================
 
-const Dashboard = ({ brokerStatus, integrityRed = false }: { brokerStatus: BrokerStatus | null; integrityRed?: boolean }) => {
+const Dashboard = ({ brokerStatus, integrityRed = false, onHealthChange }: { brokerStatus: BrokerStatus | null; integrityRed?: boolean; onHealthChange?: (s: HealthSummary) => void }) => {
     const [signals, setSignals] = useState<Signal[]>([]);
     const [trades, setTrades] = useState<Trade[]>([]);
     const [portfolio, setPortfolio] = useState<Portfolio>({
@@ -5000,6 +5001,8 @@ const Dashboard = ({ brokerStatus, integrityRed = false }: { brokerStatus: Broke
 
             {/* Zone 2: 4-Column Trading Grid */}
             <div className="dashboard-grid">
+                {/* Phase 13.6 — System Health panel: topmost, above Pending Orders */}
+                <SystemHealthPanel onHealthChange={onHealthChange} />
                 <SignalCommand
                     signals={signals}
                     newTimestamps={newTimestamps}

--- a/tcode/alpha_engine/data/logger.py
+++ b/tcode/alpha_engine/data/logger.py
@@ -132,6 +132,31 @@ class DataLogger:
         """Persist a Kelly sizing decision to fills_audit for post-trade attribution."""
         await self._queue.put(("fills_audit", audit))
 
+    async def log_heartbeat(self, component: str, status: str = "ok",
+                            detail: str | None = None,
+                            pid: int | None = None,
+                            uptime_sec: int | None = None) -> None:
+        """Persist a process heartbeat row (non-blocking, queued)."""
+        payload = {
+            "component":  component,
+            "ts":         _isotime(time.time()),
+            "status":     status,
+            "detail":     detail,
+            "pid":        pid,
+            "uptime_sec": uptime_sec,
+        }
+        await self._queue.put(("heartbeat", payload))
+
+    async def log_system_alert(self, component: str, status: str, message: str) -> None:
+        """Persist a system alert when a component goes RED."""
+        payload = {
+            "ts":        _isotime(time.time()),
+            "component": component,
+            "status":    status,
+            "message":   message,
+        }
+        await self._queue.put(("system_alert", payload))
+
     async def log_options_snapshot(self, chain: list):
         """Persist a list of options chain rows."""
         ts = _isotime(time.time())
@@ -221,6 +246,19 @@ class DataLogger:
                        (ts,ticker,strike,expiration_date,option_type,iv,bid,ask,oi,delta)
                        VALUES (:ts,:ticker,:strike,:expiration_date,:option_type,
                                :iv,:bid,:ask,:oi,:delta)""",
+                    payload,
+                )
+            elif kind == "heartbeat":
+                c.execute(
+                    """INSERT INTO process_heartbeats
+                       (component,ts,status,detail,pid,uptime_sec)
+                       VALUES (:component,:ts,:status,:detail,:pid,:uptime_sec)""",
+                    payload,
+                )
+            elif kind == "system_alert":
+                c.execute(
+                    """INSERT INTO system_alerts (ts,component,status,message)
+                       VALUES (:ts,:component,:status,:message)""",
                     payload,
                 )
             c.commit()

--- a/tcode/alpha_engine/data/schema.sql
+++ b/tcode/alpha_engine/data/schema.sql
@@ -130,3 +130,27 @@ CREATE TABLE IF NOT EXISTS signal_feedback (
 CREATE INDEX IF NOT EXISTS idx_signal_feedback_ts     ON signal_feedback(ts_feedback);
 CREATE INDEX IF NOT EXISTS idx_signal_feedback_tag    ON signal_feedback(tag);
 CREATE INDEX IF NOT EXISTS idx_signal_feedback_action ON signal_feedback(action);
+
+-- process_heartbeats: liveness pulses from every long-running component.
+-- Each component writes one row per cycle; the API reads the latest per component.
+CREATE TABLE IF NOT EXISTS process_heartbeats (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    component   TEXT    NOT NULL,   -- "publisher" | "intel_refresh" | "options_chain_api" | ...
+    ts          TEXT    NOT NULL,   -- ISO 8601 UTC
+    status      TEXT    NOT NULL,   -- "ok" | "degraded" | "error"
+    detail      TEXT,               -- last error / note, nullable
+    pid         INTEGER,
+    uptime_sec  INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_process_heartbeats_component_ts
+    ON process_heartbeats(component, ts DESC);
+
+-- system_alerts: written when any component transitions to RED status.
+-- Surfaced in the dashboard event feed.
+CREATE TABLE IF NOT EXISTS system_alerts (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts        TEXT    NOT NULL,   -- ISO 8601 UTC
+    component TEXT    NOT NULL,
+    status    TEXT    NOT NULL,   -- "error" | "degraded"
+    message   TEXT    NOT NULL
+);

--- a/tcode/alpha_engine/heartbeat.py
+++ b/tcode/alpha_engine/heartbeat.py
@@ -1,0 +1,166 @@
+"""
+Process Heartbeat — shared liveness pulse for all long-running components.
+
+Usage (sync context, e.g. ingestion modules):
+    from heartbeat import emit_heartbeat
+    emit_heartbeat("premarket", status="ok", detail="fetched 4 tickers")
+
+Usage (async context, e.g. publisher.py):
+    from heartbeat import emit_heartbeat_async
+    await emit_heartbeat_async("publisher", status="ok")
+
+Both paths write directly to the SQLite DB (~/tsla_alpha.db) and optionally
+publish to NATS subject 'system.heartbeat' when a connection is available.
+
+The sync path uses a short-lived sqlite3 connection so it is safe to call
+from any thread or process that does NOT already hold the DB connection.
+The async path delegates to DataLogger's queue so the publisher hot-path
+never blocks on disk I/O.
+"""
+import os
+import sqlite3
+import time
+import json
+from datetime import datetime, timezone
+
+DB_PATH = os.path.expanduser("~/tsla_alpha.db")
+
+# NATS connection reference — set by the publisher once connected.
+_nats_conn = None
+_process_start = time.time()
+
+
+def set_nats_conn(nc) -> None:
+    """Register the shared NATS connection so heartbeats are also published."""
+    global _nats_conn
+    _nats_conn = nc
+
+
+def _uptime() -> int:
+    return int(time.time() - _process_start)
+
+
+def _isotime() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+# ── Sync path (ingestion modules, Go subprocess calls) ───────────────────────
+
+def emit_heartbeat(
+    component: str,
+    status: str = "ok",
+    detail: str | None = None,
+    db_path: str = DB_PATH,
+) -> None:
+    """Write a heartbeat row to SQLite (synchronous, short-lived connection).
+
+    Safe to call from any thread; uses WAL so concurrent reads/writes are fine.
+    Silently swallows all exceptions — a failed heartbeat write must never
+    crash the calling component.
+    """
+    try:
+        conn = sqlite3.connect(db_path, timeout=5)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute(
+            """INSERT INTO process_heartbeats (component, ts, status, detail, pid, uptime_sec)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (component, _isotime(), status, detail, os.getpid(), _uptime()),
+        )
+        conn.commit()
+        conn.close()
+    except Exception:
+        pass  # heartbeat writes must never crash the caller
+
+    # Also write system_alert if status is error, to surface in event feed
+    if status == "error":
+        _write_system_alert(component, status, detail or f"{component} reported error", db_path)
+
+
+def _write_system_alert(
+    component: str,
+    status: str,
+    message: str,
+    db_path: str = DB_PATH,
+) -> None:
+    """Append a system_alert row. Called when a component reports error status."""
+    try:
+        conn = sqlite3.connect(db_path, timeout=5)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute(
+            """INSERT INTO system_alerts (ts, component, status, message)
+               VALUES (?, ?, ?, ?)""",
+            (_isotime(), component, status, message),
+        )
+        conn.commit()
+        conn.close()
+    except Exception:
+        pass
+
+
+def emit_heartbeat_recovered(
+    component: str,
+    db_path: str = DB_PATH,
+) -> None:
+    """Log a [HEARTBEAT-RECOVERED] alert when a component returns to ok after outage."""
+    try:
+        conn = sqlite3.connect(db_path, timeout=5)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute(
+            """INSERT INTO system_alerts (ts, component, status, message)
+               VALUES (?, ?, ?, ?)""",
+            (_isotime(), component, "ok", f"[HEARTBEAT-RECOVERED] {component} returned to ok"),
+        )
+        conn.commit()
+        conn.close()
+    except Exception:
+        pass
+
+
+# ── Async path (publisher.py / DataLogger) ───────────────────────────────────
+
+async def emit_heartbeat_async(
+    component: str,
+    status: str = "ok",
+    detail: str | None = None,
+    logger=None,
+) -> None:
+    """Async heartbeat: queues a write via DataLogger and publishes to NATS.
+
+    Args:
+        component: Component name, e.g. "publisher".
+        status: "ok" | "degraded" | "error"
+        detail: Optional error/note string.
+        logger: DataLogger instance — if None, falls back to sync sqlite write.
+    """
+    if logger is not None:
+        await logger.log_heartbeat(
+            component=component,
+            status=status,
+            detail=detail,
+            pid=os.getpid(),
+            uptime_sec=_uptime(),
+        )
+        if status == "error":
+            await logger.log_system_alert(
+                component=component,
+                status=status,
+                message=detail or f"{component} reported error",
+            )
+    else:
+        # Fallback: sync write (e.g. during shutdown)
+        emit_heartbeat(component, status, detail)
+
+    # Publish to NATS if connection is available
+    if _nats_conn is not None:
+        try:
+            payload = json.dumps({
+                "component": component,
+                "ts": _isotime(),
+                "status": status,
+                "detail": detail,
+                "pid": os.getpid(),
+                "uptime_sec": _uptime(),
+            }).encode()
+            await _nats_conn.publish("system.heartbeat", payload)
+        except Exception:
+            pass  # NATS publish is best-effort

--- a/tcode/alpha_engine/heartbeat_query.py
+++ b/tcode/alpha_engine/heartbeat_query.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+Query process_heartbeats + system_alerts for the /api/system/heartbeats endpoint.
+
+Outputs a JSON object with per-component status, age_sec, expected_max_age_sec, etc.
+Called by the Go API as a subprocess.
+
+Usage: python3 heartbeat_query.py
+"""
+import json
+import os
+import sqlite3
+import time
+from datetime import datetime, timezone
+
+DB_PATH = os.path.expanduser("~/tsla_alpha.db")
+
+# Expected max heartbeat age per component (seconds).
+# If age > expected_max, component is degraded; if age > 3×, it's error.
+EXPECTED_MAX_AGE: dict[str, int] = {
+    "publisher":          30,
+    "intel_refresh":      300,
+    "options_chain_api":  120,
+    "premarket":          120,    # only relevant during premarket window
+    "congress_trades":    3600,
+    "correlation_regime": 3600,
+    "macro_regime":       300,
+    "engine_subscriber":  90,
+    "engine_ibkr_status": 180,
+}
+
+# Premarket window: 04:00–09:30 ET
+def _is_premarket_window() -> bool:
+    try:
+        import zoneinfo
+        tz = zoneinfo.ZoneInfo("America/New_York")
+    except Exception:
+        return True
+    et = datetime.now(tz)
+    t = et.hour * 60 + et.minute
+    return 240 <= t < 570  # 4:00–9:30 AM ET
+
+
+def _compute_status(component: str, age_sec: float, last_detail: str | None) -> str:
+    """Compute ok / degraded / error based on age relative to expected cadence."""
+    # Premarket special case: if outside window, always ok
+    if component == "premarket" and not _is_premarket_window():
+        return "ok"
+    expected = EXPECTED_MAX_AGE.get(component, 300)
+    if age_sec <= expected:
+        return "ok"
+    if age_sec <= 3 * expected:
+        return "degraded"
+    return "error"
+
+
+def query_heartbeats() -> dict:
+    now_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    now_epoch = time.time()
+
+    components: dict[str, dict] = {}
+
+    if not os.path.exists(DB_PATH):
+        # DB not yet initialized — all unknown/error
+        for comp in EXPECTED_MAX_AGE:
+            components[comp] = {
+                "status": "error",
+                "last_ts": None,
+                "age_sec": None,
+                "expected_max_age_sec": EXPECTED_MAX_AGE[comp],
+                "pid": None,
+                "uptime_sec": None,
+                "detail": "db_not_found",
+            }
+        return {"ts": now_ts, "components": components}
+
+    try:
+        conn = sqlite3.connect(DB_PATH, timeout=5)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+
+        # Latest heartbeat per component
+        rows = conn.execute(
+            """
+            SELECT component, ts, status, detail, pid, uptime_sec
+            FROM process_heartbeats
+            WHERE id IN (
+                SELECT MAX(id) FROM process_heartbeats GROUP BY component
+            )
+            """
+        ).fetchall()
+        conn.close()
+    except Exception as e:
+        for comp in EXPECTED_MAX_AGE:
+            components[comp] = {
+                "status": "error",
+                "last_ts": None,
+                "age_sec": None,
+                "expected_max_age_sec": EXPECTED_MAX_AGE[comp],
+                "pid": None,
+                "uptime_sec": None,
+                "detail": f"db_error:{e}",
+            }
+        return {"ts": now_ts, "components": components}
+
+    seen: dict[str, dict] = {}
+    for row in rows:
+        comp = row["component"]
+        ts_str = row["ts"]
+        try:
+            # Parse "YYYY-MM-DD HH:MM:SS" as UTC
+            dt = datetime.strptime(ts_str, "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+            age_sec = now_epoch - dt.timestamp()
+        except Exception:
+            age_sec = 999999
+
+        status = _compute_status(comp, age_sec, row["detail"])
+
+        # Premarket off-hours special: show ok with detail skipped:off-hours
+        if comp == "premarket" and not _is_premarket_window():
+            detail = row["detail"] or "skipped:off-hours"
+        else:
+            detail = row["detail"]
+
+        seen[comp] = {
+            "status": status,
+            "last_ts": ts_str,
+            "age_sec": round(age_sec, 1),
+            "expected_max_age_sec": EXPECTED_MAX_AGE.get(comp, 300),
+            "pid": row["pid"],
+            "uptime_sec": row["uptime_sec"],
+            "detail": detail,
+        }
+
+    # Fill in never-seen components as error
+    for comp, max_age in EXPECTED_MAX_AGE.items():
+        if comp not in seen:
+            # Premarket off-hours: show ok/skipped rather than error when never pulsed
+            if comp == "premarket" and not _is_premarket_window():
+                seen[comp] = {
+                    "status": "ok",
+                    "last_ts": None,
+                    "age_sec": None,
+                    "expected_max_age_sec": max_age,
+                    "pid": None,
+                    "uptime_sec": None,
+                    "detail": "skipped:off-hours",
+                }
+            else:
+                seen[comp] = {
+                    "status": "error",
+                    "last_ts": None,
+                    "age_sec": None,
+                    "expected_max_age_sec": max_age,
+                    "pid": None,
+                    "uptime_sec": None,
+                    "detail": "no_heartbeat_received",
+                }
+
+    return {"ts": now_ts, "components": seen}
+
+
+def query_sparkline(component: str, limit: int = 10) -> list[dict]:
+    """Return the last `limit` heartbeat rows for a component (for drill-down sparkline)."""
+    if not os.path.exists(DB_PATH):
+        return []
+    try:
+        conn = sqlite3.connect(DB_PATH, timeout=5)
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            """SELECT ts, status, detail, pid, uptime_sec
+               FROM process_heartbeats
+               WHERE component = ?
+               ORDER BY id DESC LIMIT ?""",
+            (component, limit),
+        ).fetchall()
+        conn.close()
+        return [dict(r) for r in rows]
+    except Exception:
+        return []
+
+
+def query_recent_alerts(limit: int = 5) -> list[dict]:
+    """Return the latest system_alerts rows for the event feed."""
+    if not os.path.exists(DB_PATH):
+        return []
+    try:
+        conn = sqlite3.connect(DB_PATH, timeout=5)
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            """SELECT ts, component, status, message
+               FROM system_alerts
+               ORDER BY id DESC LIMIT ?""",
+            (limit,),
+        ).fetchall()
+        conn.close()
+        return [dict(r) for r in rows]
+    except Exception:
+        return []
+
+
+if __name__ == "__main__":
+    import sys
+    mode = sys.argv[1] if len(sys.argv) > 1 else "heartbeats"
+    if mode == "sparkline" and len(sys.argv) > 2:
+        print(json.dumps(query_sparkline(sys.argv[2])))
+    elif mode == "alerts":
+        print(json.dumps(query_recent_alerts()))
+    else:
+        print(json.dumps(query_heartbeats()))

--- a/tcode/alpha_engine/heartbeat_writer.py
+++ b/tcode/alpha_engine/heartbeat_writer.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""
+Minimal CLI wrapper so Go can write a heartbeat row via subprocess.
+
+Usage:
+  python3 heartbeat_writer.py --component engine_subscriber --status ok
+  python3 heartbeat_writer.py --component engine_ibkr_status --status degraded --detail "roundtrip:62s"
+
+Exit code 0 on success, 1 on error.
+"""
+import argparse
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(__file__))
+from heartbeat import emit_heartbeat
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--component", required=True)
+    parser.add_argument("--status", default="ok")
+    parser.add_argument("--detail", default=None)
+    args = parser.parse_args()
+    emit_heartbeat(args.component, args.status, args.detail)

--- a/tcode/alpha_engine/ingestion/congress_trades.py
+++ b/tcode/alpha_engine/ingestion/congress_trades.py
@@ -42,6 +42,13 @@ import requests
 
 logger = logging.getLogger("CongressTrades")
 
+try:
+    import sys as _sys
+    _sys.path.insert(0, "/home/builder/src/gpfiles/tcode/alpha_engine")
+    from heartbeat import emit_heartbeat as _hb
+except Exception:
+    def _hb(component, status="ok", detail=None, **_kw): pass  # type: ignore
+
 _CACHE: Optional[dict] = None
 _CACHE_TS: float = 0.0
 _CACHE_TTL = 3600  # 1 hour — disclosures trickle in; no need to hammer gov servers
@@ -508,6 +515,9 @@ def get_congress_trades() -> dict:
     }
     _CACHE = result
     _CACHE_TS = now
+    senate_status = result.get("senate", {}).get("status", "unknown")
+    _hb("congress_trades", status="ok" if senate_status == "ok" else "degraded",
+        detail=f"senate:{senate_status} trades:{len(all_trades)}")
     return result
 
 

--- a/tcode/alpha_engine/ingestion/correlation_regime.py
+++ b/tcode/alpha_engine/ingestion/correlation_regime.py
@@ -31,6 +31,13 @@ from typing import Optional
 
 logger = logging.getLogger("CorrelationRegime")
 
+try:
+    import sys as _sys
+    _sys.path.insert(0, "/home/builder/src/gpfiles/tcode/alpha_engine")
+    from heartbeat import emit_heartbeat as _hb
+except Exception:
+    def _hb(component, status="ok", detail=None, **_kw): pass  # type: ignore
+
 _CORR_CACHE: Optional[dict] = None
 _CORR_CACHE_TS: float = 0.0
 _CORR_TTL = 3600  # 1 hour; daily closes don't need sub-minute freshness
@@ -209,6 +216,11 @@ def get_correlation_regime() -> dict:
         return _CORR_CACHE
     _CORR_CACHE = _fetch_correlation_regime()
     _CORR_CACHE_TS = now
+    regime = _CORR_CACHE.get("regime", "NORMAL")
+    err = _CORR_CACHE.get("error")
+    _hb("correlation_regime",
+        status="ok" if not err else "degraded",
+        detail=f"regime:{regime}" + (f" err:{err}" if err else ""))
     return _CORR_CACHE
 
 

--- a/tcode/alpha_engine/ingestion/intel.py
+++ b/tcode/alpha_engine/ingestion/intel.py
@@ -11,6 +11,13 @@ import json
 import time
 from typing import Any
 
+try:
+    import sys as _sys
+    _sys.path.insert(0, "/home/builder/src/gpfiles/tcode/alpha_engine")
+    from heartbeat import emit_heartbeat as _hb
+except Exception:
+    def _hb(component, status="ok", detail=None, **_kw): pass  # type: ignore
+
 # Module-level cache: {"data": ..., "ts": float}
 _cache: dict[str, Any] = {}
 _CACHE_TTL = 300  # 5 minutes
@@ -280,6 +287,7 @@ def get_intel() -> dict:
     result = _sanitize(result)
 
     _cache = {"data": result, "ts": now}
+    _hb("intel_refresh", status="ok", detail=f"sources:news,vix,spy,earnings,options_flow,catalyst,institutional,ev_sector,macro_regime,premarket,congress,correlation_regime")
     return result
 
 

--- a/tcode/alpha_engine/ingestion/macro_regime.py
+++ b/tcode/alpha_engine/ingestion/macro_regime.py
@@ -17,6 +17,13 @@ from typing import Optional
 
 logger = logging.getLogger("MacroRegime")
 
+try:
+    import sys as _sys
+    _sys.path.insert(0, "/home/builder/src/gpfiles/tcode/alpha_engine")
+    from heartbeat import emit_heartbeat as _hb
+except Exception:
+    def _hb(component, status="ok", detail=None, **_kw): pass  # type: ignore
+
 _macro_cache: Optional[dict] = None
 _macro_cache_ts: float = 0.0
 _MACRO_TTL = 3600  # 1 hour for macro data
@@ -309,6 +316,7 @@ def get_macro_regime() -> dict:
     # Cached at VIX frequency (5 min) since it's similarly latency-tolerant
     macro["tsla_realized_vol"] = _fetch_tsla_realized_vol()
 
+    _hb("macro_regime", status="ok", detail=f"regime:{macro.get('regime','NEUTRAL')} vix:{macro.get('vix_spot',0):.1f}")
     return macro
 
 

--- a/tcode/alpha_engine/ingestion/options_chain.py
+++ b/tcode/alpha_engine/ingestion/options_chain.py
@@ -17,6 +17,13 @@ import yfinance as yf
 
 logger = logging.getLogger("OptionsChain")
 
+try:
+    import sys as _sys
+    _sys.path.insert(0, "/home/builder/src/gpfiles/tcode/alpha_engine")
+    from heartbeat import emit_heartbeat as _hb
+except Exception:
+    def _hb(component, status="ok", detail=None, **_kw): pass  # type: ignore
+
 
 # ── market-hours helper ───────────────────────────────────────────────────────
 
@@ -226,6 +233,7 @@ class OptionsChainCache:
 
         self._cache[expiry] = (now, rows)
         logger.info("Options chain loaded: %s — %d contracts (source=%s)", expiry, len(rows), source)
+        _hb("options_chain_api", status="ok", detail=f"expiry:{expiry} contracts:{len(rows)} source:{source}")
         return rows
 
     # ── public API ────────────────────────────────────────────────────────────

--- a/tcode/alpha_engine/ingestion/premarket.py
+++ b/tcode/alpha_engine/ingestion/premarket.py
@@ -19,6 +19,13 @@ from datetime import datetime, timezone, timedelta
 
 logger = logging.getLogger("PreMarket")
 
+try:
+    import sys as _sys
+    _sys.path.insert(0, "/home/builder/src/gpfiles/tcode/alpha_engine")
+    from heartbeat import emit_heartbeat as _hb
+except Exception:
+    def _hb(component, status="ok", detail=None, **_kw): pass  # type: ignore
+
 _premarket_cache: Optional[dict] = None
 _premarket_cache_ts: float = 0.0
 _PREMARKET_TTL = 60  # 1 minute — needs freshness during pre-market window
@@ -250,6 +257,11 @@ def get_premarket_intel() -> dict:
     if _premarket_cache is None or now - _premarket_cache_ts > _PREMARKET_TTL:
         _premarket_cache = _fetch_premarket()
         _premarket_cache_ts = now
+        # Heartbeat: ok if in premarket window; skipped:off-hours otherwise (NOT red)
+        if _is_premarket_window():
+            _hb("premarket", status="ok")
+        else:
+            _hb("premarket", status="ok", detail="skipped:off-hours")
 
     return _premarket_cache
 

--- a/tcode/alpha_engine/publisher.py
+++ b/tcode/alpha_engine/publisher.py
@@ -20,6 +20,7 @@ from ingestion.tv_feed import validate_spot_price, get_tv_cache, TVFeedError
 from ingestion.ibkr_feed import get_ibkr_feed
 from data.logger import DataLogger
 from config.archetypes import get_archetype, MODEL_ARCHETYPE_MAP, ARCHETYPES
+from heartbeat import emit_heartbeat_async, set_nats_conn
 
 # ── Notional account size: NEVER use portfolio NAV for sizing. ───────────────
 # Default $25k represents the small-account discipline target for live trading.
@@ -259,6 +260,7 @@ class SignalPublisher:
         """Establishing high-speed connection to the NATS broker."""
         print(f"Connecting to NATS at {self.nats_url}...")
         self.nc = await nats.connect(self.nats_url)
+        set_nats_conn(self.nc)
         print("Connected to NATS.")
 
     async def publish_signal(self, signal: ModelSignal, spot_sources: dict = None):
@@ -433,6 +435,7 @@ async def broadcast_loop():
             ok, reason = check_data_gates(spot_sources)
             if not ok:
                 print(f"[GATE BLOCKED] {reason}")
+                await emit_heartbeat_async("publisher", status="degraded", detail=f"gate_blocked:{reason}", logger=_logger)
                 await asyncio.sleep(random.uniform(10, 20))
                 continue
         except Exception as _exc:
@@ -446,6 +449,7 @@ async def broadcast_loop():
             intel = get_intel()
         except Exception as _ie:
             print(f"[INTEL] Fetch failed: {_ie}")
+            await emit_heartbeat_async("publisher", status="error", detail=f"intel_fetch_failed:{_ie}", logger=_logger)
             await asyncio.sleep(random.uniform(10, 20))
             continue
 
@@ -898,19 +902,9 @@ async def broadcast_loop():
                 await asyncio.sleep(5)
                 await publisher.connect()
 
-        # Heartbeat (always, even when no model fires)
-        heartbeat = ModelSignal(
-            model_id=ModelType.MACRO,
-            direction=SignalDirection.NEUTRAL,
-            confidence=0.5,
-            timestamp=time.time(),
-            ticker="TSLA",
-            underlying_price=spot,
-            price_source="HEARTBEAT",
-            strategy_code="IDLE_SCAN",
-            confidence_rationale="Scanning market for high-conviction patterns..."
-        )
-        await publisher.publish_signal(heartbeat)
+        # Process heartbeat — always emitted, even when no model fires.
+        # This is a liveness pulse to SQLite + NATS; NOT a trading signal.
+        await emit_heartbeat_async("publisher", status="ok", logger=_logger)
 
         # Scan interval: 10-20 seconds between full model sweeps
         await asyncio.sleep(random.uniform(10, 20))

--- a/tcode/alpha_engine/tests/test_heartbeat.py
+++ b/tcode/alpha_engine/tests/test_heartbeat.py
@@ -1,0 +1,155 @@
+"""
+Tests for heartbeat.py — process liveness pulse system.
+
+Verifies:
+1. emit_heartbeat() writes the correct row to SQLite
+2. Status promotion logic: ok → degraded → error (via heartbeat_query.py EXPECTED_MAX_AGE)
+3. system_alert row is written when status == "error"
+4. emit_heartbeat_recovered() logs a HEARTBEAT-RECOVERED system_alert
+"""
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from data.init_db import init_db
+from heartbeat import emit_heartbeat, emit_heartbeat_recovered
+
+
+@pytest.fixture()
+def tmp_db(tmp_path):
+    """Initialise a fresh tsla_alpha.db for each test."""
+    db_path = str(tmp_path / "tsla_alpha.db")
+    conn = init_db(db_path)
+    conn.close()
+    return db_path
+
+
+class TestEmitHeartbeat:
+    def test_writes_row(self, tmp_db):
+        emit_heartbeat("publisher", status="ok", db_path=tmp_db)
+        conn = sqlite3.connect(tmp_db)
+        rows = conn.execute(
+            "SELECT component, status, detail FROM process_heartbeats WHERE component='publisher'"
+        ).fetchall()
+        conn.close()
+        assert len(rows) == 1
+        assert rows[0][0] == "publisher"
+        assert rows[0][1] == "ok"
+        assert rows[0][2] is None
+
+    def test_writes_detail(self, tmp_db):
+        emit_heartbeat("intel_refresh", status="degraded",
+                        detail="FRED rate-limited", db_path=tmp_db)
+        conn = sqlite3.connect(tmp_db)
+        row = conn.execute(
+            "SELECT detail FROM process_heartbeats WHERE component='intel_refresh'"
+        ).fetchone()
+        conn.close()
+        assert row[0] == "FRED rate-limited"
+
+    def test_error_status_writes_system_alert(self, tmp_db):
+        emit_heartbeat("publisher", status="error",
+                        detail="intel_fetch_failed:ConnectionError", db_path=tmp_db)
+        conn = sqlite3.connect(tmp_db)
+        alerts = conn.execute(
+            "SELECT component, status, message FROM system_alerts"
+        ).fetchall()
+        conn.close()
+        assert len(alerts) == 1
+        assert alerts[0][0] == "publisher"
+        assert alerts[0][1] == "error"
+        assert "intel_fetch_failed" in alerts[0][2]
+
+    def test_ok_status_does_not_write_alert(self, tmp_db):
+        emit_heartbeat("publisher", status="ok", db_path=tmp_db)
+        conn = sqlite3.connect(tmp_db)
+        count = conn.execute("SELECT COUNT(*) FROM system_alerts").fetchone()[0]
+        conn.close()
+        assert count == 0
+
+    def test_multiple_components(self, tmp_db):
+        for comp in ["publisher", "intel_refresh", "options_chain_api"]:
+            emit_heartbeat(comp, db_path=tmp_db)
+        conn = sqlite3.connect(tmp_db)
+        rows = conn.execute(
+            "SELECT component FROM process_heartbeats ORDER BY id"
+        ).fetchall()
+        conn.close()
+        components = [r[0] for r in rows]
+        assert "publisher" in components
+        assert "intel_refresh" in components
+        assert "options_chain_api" in components
+
+    def test_does_not_raise_on_nonexistent_db(self, tmp_path):
+        # Must not raise even if DB hasn't been created
+        bad_path = str(tmp_path / "new_subdir" / "test.db")
+        # This will fail gracefully (SQLite will try to create the dir — it won't,
+        # but emit_heartbeat swallows exceptions)
+        try:
+            emit_heartbeat("publisher", db_path=bad_path)
+        except Exception as e:
+            pytest.fail(f"emit_heartbeat raised unexpectedly: {e}")
+
+
+class TestEmitHeartbeatRecovered:
+    def test_writes_recovery_alert(self, tmp_db):
+        emit_heartbeat_recovered("publisher", db_path=tmp_db)
+        conn = sqlite3.connect(tmp_db)
+        alerts = conn.execute(
+            "SELECT message FROM system_alerts WHERE component='publisher'"
+        ).fetchall()
+        conn.close()
+        assert len(alerts) == 1
+        assert "[HEARTBEAT-RECOVERED]" in alerts[0][0]
+
+
+class TestStatusPromotionLogic:
+    """
+    Verify the heartbeat_query.py _compute_status() function produces
+    ok / degraded / error based on age relative to expected_max_age.
+    """
+
+    def test_status_ok_within_max(self):
+        from heartbeat_query import _compute_status
+        # publisher expected_max = 30s → age 10s = ok
+        assert _compute_status("publisher", 10, None) == "ok"
+
+    def test_status_ok_at_boundary(self):
+        from heartbeat_query import _compute_status
+        assert _compute_status("publisher", 30, None) == "ok"
+
+    def test_status_degraded_above_max(self):
+        from heartbeat_query import _compute_status
+        # 31s > 30s max → degraded
+        assert _compute_status("publisher", 31, None) == "degraded"
+
+    def test_status_degraded_within_3x(self):
+        from heartbeat_query import _compute_status
+        # 60s = 2× max (30s), so still degraded
+        assert _compute_status("publisher", 60, None) == "degraded"
+
+    def test_status_error_beyond_3x(self):
+        from heartbeat_query import _compute_status
+        # 91s > 3×30s → error
+        assert _compute_status("publisher", 91, None) == "error"
+
+    def test_premarket_off_hours_always_ok(self, monkeypatch):
+        from heartbeat_query import _compute_status
+        import heartbeat_query
+        # Patch _is_premarket_window to return False (off-hours)
+        monkeypatch.setattr(heartbeat_query, "_is_premarket_window", lambda: False)
+        # Even with extreme age, premarket is ok off-hours
+        assert _compute_status("premarket", 999999, None) == "ok"
+
+    def test_premarket_in_hours_uses_normal_logic(self, monkeypatch):
+        from heartbeat_query import _compute_status
+        import heartbeat_query
+        monkeypatch.setattr(heartbeat_query, "_is_premarket_window", lambda: True)
+        # 121s > 120s max → degraded
+        assert _compute_status("premarket", 121, None) == "degraded"

--- a/tcode/alpha_engine/tests/test_publisher_heartbeat_emits.py
+++ b/tcode/alpha_engine/tests/test_publisher_heartbeat_emits.py
@@ -1,0 +1,80 @@
+"""
+Integration test: start publisher.py in a subprocess for 15 seconds, then verify
+≥ 2 publisher heartbeat rows were written to the DB.
+
+This test requires a running NATS server at nats://127.0.0.1:4222.
+If NATS is not available, the publisher will log a connection error but should
+still write heartbeats (the NATS publish path is best-effort).
+
+Skip this test in CI environments where NATS is unavailable by setting:
+  SKIP_PUBLISHER_INTEGRATION=1
+
+Design intent: this test proves that the heartbeat path in publisher.py
+actually fires during normal operation — not just that the DB schema exists.
+"""
+import os
+import signal
+import sqlite3
+import subprocess
+import sys
+import time
+
+import pytest
+
+SKIP_IF_NO_NATS = os.environ.get("SKIP_PUBLISHER_INTEGRATION") == "1"
+TCODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+VENV_PYTHON = os.path.join(TCODE_DIR, "alpha_engine/venv/bin/python")
+PUBLISHER_SCRIPT = os.path.join(TCODE_DIR, "alpha_engine/publisher.py")
+DB_PATH = os.path.expanduser("~/tsla_alpha.db")
+
+
+def _db_exists() -> bool:
+    return os.path.exists(DB_PATH)
+
+
+def _count_heartbeats(component: str) -> int:
+    if not _db_exists():
+        return 0
+    try:
+        conn = sqlite3.connect(DB_PATH, timeout=5)
+        count = conn.execute(
+            "SELECT COUNT(*) FROM process_heartbeats WHERE component=?", (component,)
+        ).fetchone()[0]
+        conn.close()
+        return count
+    except Exception:
+        return 0
+
+
+@pytest.mark.skipif(
+    SKIP_IF_NO_NATS or not os.path.exists(VENV_PYTHON),
+    reason="Publisher integration test requires venv + NATS (set SKIP_PUBLISHER_INTEGRATION=1 to skip)",
+)
+def test_publisher_emits_heartbeats():
+    """Start publisher.py for 15s and assert ≥ 2 publisher heartbeat rows in DB."""
+    before = _count_heartbeats("publisher")
+
+    proc = subprocess.Popen(
+        [VENV_PYTHON, PUBLISHER_SCRIPT],
+        cwd=TCODE_DIR,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        preexec_fn=os.setsid,  # new process group so we can kill children
+    )
+
+    try:
+        time.sleep(15)
+    finally:
+        # Send SIGTERM to the process group
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        proc.wait(timeout=5)
+
+    after = _count_heartbeats("publisher")
+    new_rows = after - before
+    assert new_rows >= 2, (
+        f"Expected ≥ 2 publisher heartbeat rows after 15s, got {new_rows} "
+        f"(before={before}, after={after})"
+    )

--- a/tcode/alpha_engine/tests/test_system_health_api.py
+++ b/tcode/alpha_engine/tests/test_system_health_api.py
@@ -1,0 +1,157 @@
+"""
+Tests for heartbeat_query.py — /api/system/heartbeats aggregation logic.
+
+Verifies:
+1. query_heartbeats() returns all expected components
+2. Age and status are computed correctly from DB rows
+3. Premarket off-hours special case: ok with "skipped:off-hours"
+4. Never-seen components return error status
+5. query_sparkline() returns recent rows for a given component
+6. query_recent_alerts() returns system_alerts in reverse order
+"""
+import os
+import sqlite3
+import sys
+import time
+from datetime import datetime, timezone, timedelta
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from data.init_db import init_db
+from heartbeat import emit_heartbeat
+import heartbeat_query
+
+
+EXPECTED_COMPONENTS = {
+    "publisher", "intel_refresh", "options_chain_api", "premarket",
+    "congress_trades", "correlation_regime", "macro_regime",
+    "engine_subscriber", "engine_ibkr_status",
+}
+
+
+@pytest.fixture()
+def fresh_db(tmp_path, monkeypatch):
+    """Initialise DB, patch DB_PATH in heartbeat_query, return path."""
+    db_path = str(tmp_path / "tsla_alpha.db")
+    conn = init_db(db_path)
+    conn.close()
+    monkeypatch.setattr(heartbeat_query, "DB_PATH", db_path)
+    return db_path
+
+
+def insert_heartbeat(db_path: str, component: str, status: str = "ok",
+                     detail: str | None = None, age_sec: int = 5) -> None:
+    """Insert a heartbeat row with a timestamp `age_sec` seconds in the past."""
+    ts = (datetime.now(timezone.utc) - timedelta(seconds=age_sec)).strftime("%Y-%m-%d %H:%M:%S")
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO process_heartbeats (component, ts, status, detail, pid, uptime_sec) VALUES (?,?,?,?,?,?)",
+        (component, ts, status, detail, 12345, 3600),
+    )
+    conn.commit()
+    conn.close()
+
+
+class TestQueryHeartbeats:
+    def test_returns_all_expected_components(self, fresh_db, monkeypatch):
+        monkeypatch.setattr(heartbeat_query, "_is_premarket_window", lambda: True)
+        result = heartbeat_query.query_heartbeats()
+        assert set(result["components"].keys()) == EXPECTED_COMPONENTS
+
+    def test_fresh_heartbeat_is_ok(self, fresh_db, monkeypatch):
+        monkeypatch.setattr(heartbeat_query, "_is_premarket_window", lambda: True)
+        insert_heartbeat(fresh_db, "publisher", "ok", age_sec=5)
+        result = heartbeat_query.query_heartbeats()
+        comp = result["components"]["publisher"]
+        assert comp["status"] == "ok"
+        assert comp["age_sec"] is not None
+        assert comp["age_sec"] < 30  # publisher max age
+
+    def test_stale_heartbeat_is_degraded(self, fresh_db, monkeypatch):
+        monkeypatch.setattr(heartbeat_query, "_is_premarket_window", lambda: True)
+        # publisher max = 30s; 60s = 2× → degraded
+        insert_heartbeat(fresh_db, "publisher", "ok", age_sec=60)
+        result = heartbeat_query.query_heartbeats()
+        assert result["components"]["publisher"]["status"] == "degraded"
+
+    def test_very_stale_heartbeat_is_error(self, fresh_db, monkeypatch):
+        monkeypatch.setattr(heartbeat_query, "_is_premarket_window", lambda: True)
+        # publisher max = 30s; 95s = > 3× → error
+        insert_heartbeat(fresh_db, "publisher", "ok", age_sec=95)
+        result = heartbeat_query.query_heartbeats()
+        assert result["components"]["publisher"]["status"] == "error"
+
+    def test_never_seen_component_is_error(self, fresh_db, monkeypatch):
+        monkeypatch.setattr(heartbeat_query, "_is_premarket_window", lambda: True)
+        # Don't insert any heartbeat for publisher
+        result = heartbeat_query.query_heartbeats()
+        assert result["components"]["publisher"]["status"] == "error"
+        assert result["components"]["publisher"]["last_ts"] is None
+
+    def test_premarket_off_hours_is_ok_even_when_stale(self, fresh_db, monkeypatch):
+        monkeypatch.setattr(heartbeat_query, "_is_premarket_window", lambda: False)
+        # Premarket never pulsed — but off-hours so should be ok
+        result = heartbeat_query.query_heartbeats()
+        comp = result["components"]["premarket"]
+        assert comp["status"] == "ok"
+        assert "skipped:off-hours" in (comp["detail"] or "")
+
+    def test_premarket_off_hours_overrides_age(self, fresh_db, monkeypatch):
+        monkeypatch.setattr(heartbeat_query, "_is_premarket_window", lambda: False)
+        # Insert a very stale premarket heartbeat
+        insert_heartbeat(fresh_db, "premarket", "ok", age_sec=9999)
+        result = heartbeat_query.query_heartbeats()
+        # Off-hours overrides stale age → still ok
+        assert result["components"]["premarket"]["status"] == "ok"
+
+    def test_returns_expected_max_age_sec(self, fresh_db, monkeypatch):
+        monkeypatch.setattr(heartbeat_query, "_is_premarket_window", lambda: True)
+        result = heartbeat_query.query_heartbeats()
+        assert result["components"]["publisher"]["expected_max_age_sec"] == 30
+        assert result["components"]["congress_trades"]["expected_max_age_sec"] == 3600
+
+
+class TestQuerySparkline:
+    def test_returns_rows_for_component(self, fresh_db, monkeypatch):
+        monkeypatch.setattr(heartbeat_query, "DB_PATH", fresh_db)
+        for i in range(5):
+            insert_heartbeat(fresh_db, "publisher", "ok", age_sec=i * 30)
+        rows = heartbeat_query.query_sparkline("publisher", limit=10)
+        assert len(rows) == 5
+        for r in rows:
+            assert "ts" in r
+            assert "status" in r
+
+    def test_returns_empty_for_unknown_component(self, fresh_db, monkeypatch):
+        monkeypatch.setattr(heartbeat_query, "DB_PATH", fresh_db)
+        rows = heartbeat_query.query_sparkline("nonexistent_component")
+        assert rows == []
+
+    def test_respects_limit(self, fresh_db, monkeypatch):
+        monkeypatch.setattr(heartbeat_query, "DB_PATH", fresh_db)
+        for i in range(15):
+            insert_heartbeat(fresh_db, "publisher", age_sec=i)
+        rows = heartbeat_query.query_sparkline("publisher", limit=10)
+        assert len(rows) == 10
+
+
+class TestQueryRecentAlerts:
+    def test_returns_alerts(self, fresh_db, monkeypatch):
+        monkeypatch.setattr(heartbeat_query, "DB_PATH", fresh_db)
+        conn = sqlite3.connect(fresh_db)
+        for i in range(3):
+            conn.execute(
+                "INSERT INTO system_alerts (ts, component, status, message) VALUES (?,?,?,?)",
+                ("2026-04-14 10:00:00", "publisher", "error", f"alert {i}"),
+            )
+        conn.commit()
+        conn.close()
+        alerts = heartbeat_query.query_recent_alerts(limit=5)
+        assert len(alerts) == 3
+        assert all("component" in a for a in alerts)
+
+    def test_empty_when_no_alerts(self, fresh_db, monkeypatch):
+        monkeypatch.setattr(heartbeat_query, "DB_PATH", fresh_db)
+        assert heartbeat_query.query_recent_alerts() == []

--- a/tcode/alpha_engine/tests/ux_system_health.spec.ts
+++ b/tcode/alpha_engine/tests/ux_system_health.spec.ts
@@ -1,0 +1,202 @@
+/**
+ * ux_system_health.spec.ts — Playwright tests for SystemHealthPanel (Phase 13.6).
+ *
+ * Verifies:
+ *   1. All-ok mock → header badge green, panel shows all green LEDs
+ *   2. Publisher stale (5min) → header badge red, publisher row red, drill-down shows details
+ *   3. Click drill-down → popover renders with sparkline + restart button
+ *   4. Click restart → confirmation modal with 3s countdown
+ *   5. All component-name labels have data-glossary-term attributes (TermLabel coverage)
+ */
+import { test, expect, Page, Route } from '@playwright/test';
+
+const BASE_URL = process.env.ACC_URL ?? 'http://localhost:2112';
+
+const NOW_TS = '2026-04-14T13:31:00Z';
+
+function makeAllOkPayload() {
+  return {
+    ts: NOW_TS,
+    components: {
+      publisher:          { status: 'ok', last_ts: '2026-04-14 13:30:58', age_sec: 2,   expected_max_age_sec: 30,   pid: 1771075, uptime_sec: 60500, detail: null },
+      intel_refresh:      { status: 'ok', last_ts: '2026-04-14 13:30:50', age_sec: 10,  expected_max_age_sec: 300,  pid: 1771075, uptime_sec: 60500, detail: null },
+      options_chain_api:  { status: 'ok', last_ts: '2026-04-14 13:30:45', age_sec: 15,  expected_max_age_sec: 120,  pid: 1771075, uptime_sec: 60500, detail: null },
+      premarket:          { status: 'ok', last_ts: null,                  age_sec: null, expected_max_age_sec: 120,  pid: null,    uptime_sec: null,  detail: 'skipped:off-hours' },
+      congress_trades:    { status: 'ok', last_ts: '2026-04-14 12:00:00', age_sec: 5460, expected_max_age_sec: 3600, pid: 1771075, uptime_sec: 60500, detail: null },
+      correlation_regime: { status: 'ok', last_ts: '2026-04-14 12:00:00', age_sec: 5460, expected_max_age_sec: 3600, pid: 1771075, uptime_sec: 60500, detail: null },
+      macro_regime:       { status: 'ok', last_ts: '2026-04-14 13:30:55', age_sec: 5,   expected_max_age_sec: 300,  pid: 1771075, uptime_sec: 60500, detail: null },
+      engine_subscriber:  { status: 'ok', last_ts: '2026-04-14 13:30:30', age_sec: 30,  expected_max_age_sec: 90,   pid: 9001,    uptime_sec: 60500, detail: null },
+      engine_ibkr_status: { status: 'ok', last_ts: '2026-04-14 13:30:00', age_sec: 60,  expected_max_age_sec: 180,  pid: 9001,    uptime_sec: 60500, detail: null },
+    },
+  };
+}
+
+function makePublisherDeadPayload() {
+  const payload = makeAllOkPayload();
+  payload.components.publisher = {
+    status: 'error',
+    last_ts: '2026-04-14 13:25:58',
+    age_sec: 302,
+    expected_max_age_sec: 30,
+    pid: null,
+    uptime_sec: null,
+    detail: 'no_heartbeat_received',
+  };
+  return payload;
+}
+
+const ALL_OK_SPARKLINE: object[] = [
+  { ts: '2026-04-14 13:30:58', status: 'ok', detail: null, pid: 1771075, uptime_sec: 60500 },
+  { ts: '2026-04-14 13:30:45', status: 'ok', detail: null, pid: 1771075, uptime_sec: 60480 },
+];
+
+async function mockHeartbeatsRoute(page: Page, payload: object) {
+  await page.route('**/api/system/heartbeats', (route: Route) => {
+    if (route.request().url().includes('/sparkline') || route.request().url().includes('/restart')) {
+      route.continue();
+      return;
+    }
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+    });
+  });
+}
+
+async function mockSparklineRoute(page: Page, component: string, rows: object[]) {
+  await page.route(`**/api/system/heartbeats/${component}/sparkline`, (route: Route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(rows),
+    });
+  });
+}
+
+async function loadDashboard(page: Page) {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto(BASE_URL, { waitUntil: 'networkidle', timeout: 20000 });
+  await page.waitForTimeout(1500);
+}
+
+test.describe('SystemHealthPanel', () => {
+
+  test('all-ok: header badge is green, all rows are green LEDs', async ({ page }) => {
+    await mockHeartbeatsRoute(page, makeAllOkPayload());
+    await loadDashboard(page);
+
+    // Header badge exists
+    const badge = page.locator('[data-testid="system-health-badge"]');
+    await expect(badge).toBeVisible({ timeout: 5000 });
+
+    // Badge text includes "ok" (not error/degraded)
+    const badgeText = await badge.textContent();
+    expect(badgeText).toMatch(/9\s*\/\s*9\s*ok/i);
+
+    // All component rows are present
+    for (const comp of ['publisher', 'intel_refresh', 'engine_subscriber']) {
+      const row = page.locator(`[data-testid="sph-row-${comp}"]`);
+      await expect(row).toBeVisible();
+      // Row should not have red/degraded class
+      const cls = await row.getAttribute('class') ?? '';
+      expect(cls).not.toContain('error');
+      expect(cls).not.toContain('degraded');
+    }
+  });
+
+  test('publisher stale 5min: header badge red, publisher row error', async ({ page }) => {
+    await mockHeartbeatsRoute(page, makePublisherDeadPayload());
+    await mockSparklineRoute(page, 'publisher', []);
+    await loadDashboard(page);
+
+    // Header badge should be red/pulsing
+    const badge = page.locator('[data-testid="system-health-badge"]');
+    await expect(badge).toBeVisible({ timeout: 5000 });
+    const badgeText = await badge.textContent();
+    expect(badgeText?.toLowerCase()).toMatch(/error/i);
+
+    // Publisher row should have error class
+    const publisherRow = page.locator('[data-testid="sph-row-publisher"]');
+    await expect(publisherRow).toBeVisible();
+    const cls = await publisherRow.getAttribute('class') ?? '';
+    expect(cls).toContain('error');
+
+    // Age shown as something like "5m ago"
+    const rowText = await publisherRow.textContent();
+    expect(rowText).toMatch(/\d+[smh]/);
+  });
+
+  test('click publisher row: drill-down popover opens with details', async ({ page }) => {
+    await mockHeartbeatsRoute(page, makePublisherDeadPayload());
+    await mockSparklineRoute(page, 'publisher', ALL_OK_SPARKLINE);
+    await loadDashboard(page);
+
+    // Click the publisher row
+    const publisherRow = page.locator('[data-testid="sph-row-publisher"]');
+    await expect(publisherRow).toBeVisible({ timeout: 5000 });
+    await publisherRow.click();
+
+    // Drill-down dialog should appear
+    const dialog = page.locator('[role="dialog"][aria-label*="publisher"]');
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    // Should show expected cadence info
+    const dialogText = await dialog.textContent();
+    expect(dialogText).toMatch(/30s/);  // expected cadence
+    expect(dialogText).toMatch(/error/i);
+
+    // Sparkline label should appear
+    await expect(dialog.locator('.sph-sparkline-label')).toBeVisible();
+
+    // Restart button should be visible (publisher is restartable)
+    const restartBtn = dialog.locator('[data-testid="restart-service-btn"]');
+    await expect(restartBtn).toBeVisible();
+  });
+
+  test('click restart button: confirmation modal with 3s countdown', async ({ page }) => {
+    await mockHeartbeatsRoute(page, makePublisherDeadPayload());
+    await mockSparklineRoute(page, 'publisher', []);
+    await loadDashboard(page);
+
+    // Open publisher drill-down
+    const publisherRow = page.locator('[data-testid="sph-row-publisher"]');
+    await publisherRow.click();
+    const dialog = page.locator('[role="dialog"][aria-label*="publisher"]');
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    // Click restart button
+    const restartBtn = dialog.locator('[data-testid="restart-service-btn"]');
+    await restartBtn.click();
+
+    // Confirmation modal should appear
+    const confirmModal = page.locator('[data-testid="restart-confirm-btn"]');
+    await expect(confirmModal).toBeVisible({ timeout: 3000 });
+
+    // Initially disabled with countdown
+    const isDisabled = await confirmModal.isDisabled();
+    expect(isDisabled).toBe(true);
+
+    // Button text should show countdown number
+    const btnText = await confirmModal.textContent();
+    expect(btnText).toMatch(/Restart \(\d\)/);
+
+    // Wait for countdown to complete (3.5s)
+    await page.waitForTimeout(3500);
+    const isDisabledAfter = await confirmModal.isDisabled();
+    expect(isDisabledAfter).toBe(false);
+  });
+
+  test('component labels have data-glossary-term attributes', async ({ page }) => {
+    await mockHeartbeatsRoute(page, makeAllOkPayload());
+    await loadDashboard(page);
+
+    // Each component row should contain a TermLabel (data-glossary-term attribute)
+    const EXPECTED_TERMS = ['PUBLISHER', 'INTEL_REFRESH', 'ENGINE_SUBSCRIBER', 'IBKR_GATEWAY'];
+    for (const term of EXPECTED_TERMS) {
+      const el = page.locator(`[data-glossary-term="${term}"]`);
+      await expect(el).toBeVisible({ timeout: 5000 });
+    }
+  });
+
+});

--- a/tcode/execution_engine/api.go
+++ b/tcode/execution_engine/api.go
@@ -2582,6 +2582,137 @@ func (h *ConfigHandler) ServeSignalFeedbackResolve(w http.ResponseWriter, r *htt
 	json.NewEncoder(w).Encode(result)
 }
 
+// ── /api/system/heartbeats ────────────────────────────────────────────────────
+
+// ServeSystemHeartbeats handles GET /api/system/heartbeats.
+// Queries process_heartbeats via Python subprocess and returns per-component status.
+func (h *ConfigHandler) ServeSystemHeartbeats(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	cmd := exec.Command("./alpha_engine/venv/bin/python",
+		"alpha_engine/heartbeat_query.py", "heartbeats")
+	cmd.Dir = "/home/builder/src/gpfiles/tcode"
+	cmd.Env = os.Environ()
+
+	out, err := cmd.Output()
+	if err != nil {
+		http.Error(w, `{"error":"heartbeat query failed"}`, http.StatusInternalServerError)
+		return
+	}
+	w.Write(out)
+}
+
+// ServeSystemHeartbeatSparkline handles GET /api/system/heartbeats/{component}/sparkline.
+func (h *ConfigHandler) ServeSystemHeartbeatSparkline(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	// Extract component from path: /api/system/heartbeats/{component}/sparkline
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/system/heartbeats/"), "/")
+	if len(parts) < 1 || parts[0] == "" {
+		http.Error(w, `{"error":"component required"}`, http.StatusBadRequest)
+		return
+	}
+	component := parts[0]
+
+	cmd := exec.Command("./alpha_engine/venv/bin/python",
+		"alpha_engine/heartbeat_query.py", "sparkline", component)
+	cmd.Dir = "/home/builder/src/gpfiles/tcode"
+	cmd.Env = os.Environ()
+
+	out, err := cmd.Output()
+	if err != nil {
+		w.Write([]byte("[]"))
+		return
+	}
+	w.Write(out)
+}
+
+// ServeSystemHeartbeatRestart handles POST /api/system/heartbeats/{component}/restart.
+// Shells out `systemctl --user restart <unit>` — localhost-only requests only.
+// The component-to-unit map is a static allow-list; no user-supplied unit names.
+func (h *ConfigHandler) ServeSystemHeartbeatRestart(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	if r.Method == "OPTIONS" {
+		w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		return
+	}
+	if r.Method != "POST" {
+		http.Error(w, `{"error":"POST required"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Restrict to localhost — restart is a privileged action.
+	host, _, splitErr := net.SplitHostPort(r.RemoteAddr)
+	if splitErr != nil {
+		host = r.RemoteAddr
+	}
+	if host != "127.0.0.1" && host != "::1" {
+		http.Error(w, `{"error":"restart only allowed from localhost"}`, http.StatusForbidden)
+		return
+	}
+
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/system/heartbeats/"), "/")
+	if len(parts) < 1 {
+		http.Error(w, `{"error":"component required"}`, http.StatusBadRequest)
+		return
+	}
+	component := parts[0]
+
+	// Static allow-list — never exec a user-supplied unit name.
+	componentToUnit := map[string]string{
+		"publisher":          "publisher.service",
+		"engine_subscriber":  "executor.service",
+		"engine_ibkr_status": "executor.service",
+	}
+	unit, ok := componentToUnit[component]
+	if !ok {
+		http.Error(w, `{"error":"unknown component — cannot restart"}`, http.StatusBadRequest)
+		return
+	}
+
+	out, err := exec.Command("systemctl", "--user", "restart", unit).CombinedOutput()
+	if err != nil {
+		resp := map[string]interface{}{
+			"ok":      false,
+			"unit":    unit,
+			"error":   err.Error(),
+			"output":  string(out),
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(resp)
+		return
+	}
+
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"ok":   true,
+		"unit": unit,
+		"msg":  fmt.Sprintf("systemctl --user restart %s succeeded", unit),
+	})
+}
+
+// ServeSystemAlerts handles GET /api/system/alerts — recent system alert rows.
+func (h *ConfigHandler) ServeSystemAlerts(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	cmd := exec.Command("./alpha_engine/venv/bin/python",
+		"alpha_engine/heartbeat_query.py", "alerts")
+	cmd.Dir = "/home/builder/src/gpfiles/tcode"
+	cmd.Env = os.Environ()
+
+	out, err := cmd.Output()
+	if err != nil {
+		w.Write([]byte("[]"))
+		return
+	}
+	w.Write(out)
+}
+
 func RequestLoggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()

--- a/tcode/execution_engine/main.go
+++ b/tcode/execution_engine/main.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -234,6 +235,21 @@ func main() {
 	mux.HandleFunc("/api/signals/feedback", configHandler.ServeSignalFeedback)
 	mux.HandleFunc("/api/signals/cancel", configHandler.ServeSignalCancel)
 
+	// System heartbeats (Phase 13.6)
+	mux.HandleFunc("/api/system/heartbeats", configHandler.ServeSystemHeartbeats)
+	mux.HandleFunc("/api/system/alerts", configHandler.ServeSystemAlerts)
+	// Prefix-match for /{component}/sparkline and /{component}/restart
+	mux.HandleFunc("/api/system/heartbeats/", func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		if strings.HasSuffix(path, "/sparkline") {
+			configHandler.ServeSystemHeartbeatSparkline(w, r)
+		} else if strings.HasSuffix(path, "/restart") {
+			configHandler.ServeSystemHeartbeatRestart(w, r)
+		} else {
+			http.NotFound(w, r)
+		}
+	})
+
 	// Live Reload WebSocket (Task: Auto-Refresh)
 	mux.Handle("/dev/ws", GlobalReloader)
 	mux.HandleFunc("/dev/reload", TriggerReloadHandler)
@@ -293,6 +309,20 @@ func main() {
 
 	// Phase 13: keep cancelled-signal cache current (10s refresh from DB)
 	StartCancelRefreshLoop()
+
+	// Phase 13.6: IBKR status heartbeat — 60s ticker, polls open orders as liveness probe.
+	go func() {
+		ticker := time.NewTicker(60 * time.Second)
+		defer ticker.Stop()
+		for range ticker.C {
+			_, err := OpenIBKROrders()
+			if err != nil {
+				emitEngineHeartbeat("engine_ibkr_status", "degraded", err.Error())
+			} else {
+				emitEngineHeartbeat("engine_ibkr_status", "ok", "")
+			}
+		}
+	}()
 
 	// Periodic Portfolio Revaluation (Task: Real-time NAV & Unrealized PnL)
 	go func() {

--- a/tcode/execution_engine/subscriber.go
+++ b/tcode/execution_engine/subscriber.go
@@ -628,6 +628,34 @@ func (s *SignalSubscriber) Start() {
 	if err != nil {
 		log.Fatalf("Subscription Error: %v", err)
 	}
+
+	// Engine subscriber heartbeat: tick every 30s to signal this process is alive.
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for range ticker.C {
+			emitEngineHeartbeat("engine_subscriber", "ok", "")
+		}
+	}()
+}
+
+// emitEngineHeartbeat writes a heartbeat row via the Python heartbeat_writer subprocess.
+// Non-blocking on errors — a failed heartbeat write must never crash the engine.
+func emitEngineHeartbeat(component, status, detail string) {
+	args := []string{
+		"alpha_engine/venv/bin/python",
+		"alpha_engine/heartbeat_writer.py",
+		"--component", component,
+		"--status", status,
+	}
+	if detail != "" {
+		args = append(args, "--detail", detail)
+	}
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Dir = "/home/builder/src/gpfiles/tcode"
+	if err := cmd.Run(); err != nil {
+		log.Printf("[HEARTBEAT] write failed for %s: %v", component, err)
+	}
 }
 
 func (s *SignalSubscriber) Close() {


### PR DESCRIPTION
## Summary

**Motivation:** On 2026-04-13, publisher.service was dead all day — unit file pointed at an abandoned path, exited 203/EXEC on every restart. Dashboard showed engine/NATS/IBKR all green. No signals generated. This phase makes that failure mode impossible to miss.

**What ships:**

- **Publisher heartbeat** — `emit_heartbeat_async("publisher")` after every signal-generation cycle (ok), on gate-blocked (degraded), on intel-fetch-fail (error). Fake `IDLE_SCAN` ModelSignal heartbeat replaced with real liveness pulse.
- **All 9 components instrumented** — publisher, intel_refresh, options_chain_api, premarket (off-hours exemption), congress_trades, correlation_regime, macro_regime, engine_subscriber (30s Go goroutine), engine_ibkr_status (60s OpenIBKROrders probe).
- **SQLite tables** — `process_heartbeats(component, ts, status, detail, pid, uptime_sec)` + `system_alerts(ts, component, status, message)`.
- **NATS** — heartbeats published to `system.heartbeat` (best-effort).
- **Go API** — `GET /api/system/heartbeats`, `GET /api/system/heartbeats/{component}/sparkline`, `POST /api/system/heartbeats/{component}/restart` (localhost-only, 3-component allow-list), `GET /api/system/alerts`.
- **SystemHealthPanel.tsx** — LED grid (green/amber/red) for all 9 components with TermLabel, last-heartbeat age, expected cadence. Drill-down: last-heartbeat ts, age, PID, uptime, last detail, sparkline (last 10 rows), restart button.
- **Header badge** — `<SystemHealthBadge>` always visible next to IntegrityStatus; green/amber/red; pulses with animation on error. Cannot be missed.
- **Restart confirmation** — 3-second countdown modal before `systemctl --user restart`; systemctl exit code surfaced in UI toast on failure.
- **Glossary** — HEARTBEAT, EXPECTED_CADENCE, FLAPPING, PUBLISHER, INTEL_REFRESH, OPTIONS_CHAIN_API, ENGINE_SUBSCRIBER, IBKR_GATEWAY, NATS. HEARTBEAT entry documents the 2026-04-13 incident.
- **27 unit + API tests passing** — emit/read, status promotion (ok/degraded/error), premarket off-hours exception, sparkline, alerts.
- **Playwright spec** — all-ok → green badge; publisher-dead → red badge + row; drill-down; 3s countdown; TermLabel coverage.

## Test plan
- [ ] `pytest tests/test_heartbeat.py tests/test_system_health_api.py` — 27 tests pass
- [ ] `go build ./...` from execution_engine — compiles clean
- [ ] `npm run build` from alpha_control_center — TypeScript clean
- [ ] UX gate passed on push
- [ ] Manual: `systemctl --user stop publisher.service` → within 90s publisher row amber → 3min red → header badge red
- [ ] Manual: `systemctl --user start publisher.service` → within 60s row returns green
- [ ] `curl /api/system/heartbeats | jq` — all 9 components with realistic ages

## PR command (run after gh auth login)
```
gh pr create --repo franksbaz/gpfiles --head mmucklo:feat/stabilization-phase-13-6-publisher-heartbeat --base master --fill
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
