### PR TITLE
fix(ui): Stabilization Phase 14.2 — SignalPanel breakdown React error #31

### DIFF
--- a/tcode/alpha_control_center/src/components/SystemMonitor.tsx
+++ b/tcode/alpha_control_center/src/components/SystemMonitor.tsx
@@ -4,6 +4,7 @@ import './SystemMonitor.css';
 import Tooltip from './Tooltip';
 
 import { useDataFetching } from '../hooks';
+import { parseBreakdownByModel } from '../lib/breakdown_parser';
 
 // Collapsible Panel Component
 const Panel = ({ title, icon, storageKey, children }: { title: string, icon: React.ReactNode, storageKey: string, children: React.ReactNode }) => {
@@ -281,9 +282,16 @@ const SignalPanel = () => {
                         ))}
                     </div>
                     <div className="vitals-grid" style={{marginTop: '1rem'}}>
-                        {Object.entries(breakdown).map(([strategy, count]) => (
-                            <VitalsCard key={strategy} label={strategy} value={count as number} />
-                        ))}
+                        {(() => {
+                            const byModel = parseBreakdownByModel(breakdown);
+                            const entries = Object.entries(byModel);
+                            if (entries.length === 0) {
+                                return <VitalsCard label="Signals 30d" value={0} />;
+                            }
+                            return entries.map(([modelName, count]) => (
+                                <VitalsCard key={modelName} label={modelName} value={count} />
+                            ));
+                        })()}
                     </div>
                 </>
             )}

--- a/tcode/alpha_control_center/src/lib/breakdown_parser.test.ts
+++ b/tcode/alpha_control_center/src/lib/breakdown_parser.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for breakdown_parser.ts
+ * Regression guard for Phase 14.2: React error #31 caused by rendering an
+ * attribution object as a React child via the old `as number` cast.
+ *
+ * Run with: npx vitest run src/lib/breakdown_parser.test.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseBreakdownByModel } from './breakdown_parser';
+
+// ── new Phase-14 shape ─────────────────────────────────────────────────────────
+
+const NEW_SHAPE = {
+    attribution: {
+        by_model: {
+            '30d': {
+                SENTIMENT: { count: 42, avg_confidence: 0.78, avg_selection_score: 0.85 },
+                MACRO: { count: 17, avg_confidence: 0.65, avg_selection_score: null },
+                CONTRARIAN: { count: 5, avg_confidence: 0.55, avg_selection_score: 0.60 },
+            },
+            '60d': {
+                SENTIMENT: { count: 90, avg_confidence: 0.76, avg_selection_score: 0.84 },
+            },
+        },
+        by_chop_regime: {},
+        by_score_bin: {},
+        windows: ['30d', '60d'],
+        generated_at: '2026-04-14T10:00:00Z',
+        note: 'rolling attribution',
+    },
+};
+
+// ── old pre-Phase-14 shape ────────────────────────────────────────────────────
+
+const OLD_SHAPE = { SENTIMENT: 123, MACRO: 45 };
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('parseBreakdownByModel — new Phase-14 shape', () => {
+    it('returns per-model counts for the default 30d window', () => {
+        const result = parseBreakdownByModel(NEW_SHAPE);
+        expect(result).toEqual({ SENTIMENT: 42, MACRO: 17, CONTRARIAN: 5 });
+    });
+
+    it('every value in the result is a number', () => {
+        const result = parseBreakdownByModel(NEW_SHAPE);
+        for (const v of Object.values(result)) {
+            expect(typeof v).toBe('number');
+        }
+    });
+
+    it('returns correct counts for an explicit 60d window', () => {
+        const result = parseBreakdownByModel(NEW_SHAPE, '60d');
+        expect(result).toEqual({ SENTIMENT: 90 });
+    });
+});
+
+describe('parseBreakdownByModel — guard cases (must never crash, never return objects)', () => {
+    it('returns {} for null', () => {
+        expect(parseBreakdownByModel(null)).toEqual({});
+    });
+
+    it('returns {} for undefined', () => {
+        expect(parseBreakdownByModel(undefined)).toEqual({});
+    });
+
+    it('returns {} for empty object {}', () => {
+        expect(parseBreakdownByModel({})).toEqual({});
+    });
+
+    it('returns {} for old flat shape {SENTIMENT: 123, MACRO: 45} (no attribution key)', () => {
+        // Old shape has no `attribution` key → parseBreakdownByModel returns {}
+        // Caller renders "Signals 30d: 0" fallback card — no crash, no [object Object]
+        const result = parseBreakdownByModel(OLD_SHAPE);
+        expect(result).toEqual({});
+    });
+
+    it('returns {} when attribution exists but by_model is missing', () => {
+        const partial = { attribution: { by_score_bin: {}, generated_at: '...' } };
+        const result = parseBreakdownByModel(partial);
+        expect(result).toEqual({});
+    });
+
+    it('returns {} when by_model exists but requested window is missing', () => {
+        const partial = { attribution: { by_model: { '60d': { SENTIMENT: { count: 10 } } } } };
+        const result = parseBreakdownByModel(partial);  // defaults to '30d'
+        expect(result).toEqual({});
+    });
+
+    it('handles missing count field gracefully — returns 0 for that model', () => {
+        const noCount = {
+            attribution: {
+                by_model: {
+                    '30d': {
+                        SENTIMENT: { avg_confidence: 0.78 },  // no count
+                        MACRO: { count: 5 },
+                    },
+                },
+            },
+        };
+        const result = parseBreakdownByModel(noCount);
+        expect(result['SENTIMENT']).toBe(0);
+        expect(result['MACRO']).toBe(5);
+    });
+
+    it('never returns a non-number value for any key', () => {
+        // Feed it a malformed shape where count is a string or object
+        const malformed = {
+            attribution: {
+                by_model: {
+                    '30d': {
+                        MODEL_A: { count: '42' as unknown as number },   // string — should coerce to 0
+                        MODEL_B: { count: { nested: true } as unknown as number },  // object — should be 0
+                    },
+                },
+            },
+        };
+        const result = parseBreakdownByModel(malformed);
+        for (const v of Object.values(result)) {
+            expect(typeof v).toBe('number');
+        }
+    });
+});

--- a/tcode/alpha_control_center/src/lib/breakdown_parser.ts
+++ b/tcode/alpha_control_center/src/lib/breakdown_parser.ts
@@ -1,0 +1,44 @@
+/**
+ * Parses the /api/metrics/signals/breakdown response into a flat { [modelName]: count } map.
+ *
+ * Phase 14 shape:
+ *   { attribution: { by_model: { "30d": { "MODEL_NAME": { count, avg_confidence, avg_selection_score } } } } }
+ *
+ * Pre-Phase-14 shape (no longer produced but guarded against to avoid crashes):
+ *   { SENTIMENT: 123, MACRO: 45, ... }
+ *
+ * Returns an empty object if the shape is unrecognised.
+ */
+export function parseBreakdownByModel(
+    breakdown: unknown,
+    window = '30d',
+): Record<string, number> {
+    if (!breakdown || typeof breakdown !== 'object') return {};
+
+    const b = breakdown as Record<string, unknown>;
+    const attribution = b['attribution'];
+
+    if (!attribution || typeof attribution !== 'object') return {};
+
+    const byModel = (attribution as Record<string, unknown>)['by_model'];
+    if (!byModel || typeof byModel !== 'object') {
+        console.warn('[SIGNALPANEL-UNEXPECTED-SHAPE] attribution present but by_model missing; keys=', Object.keys(attribution as object));
+        return {};
+    }
+
+    const windowData = (byModel as Record<string, unknown>)[window];
+    if (!windowData || typeof windowData !== 'object') {
+        console.warn('[SIGNALPANEL-UNEXPECTED-SHAPE] attribution present but by_model.' + window + ' missing; by_model keys=', Object.keys(byModel as object));
+        return {};
+    }
+
+    const result: Record<string, number> = {};
+    for (const [modelName, stats] of Object.entries(windowData as Record<string, unknown>)) {
+        const count =
+            stats && typeof stats === 'object' && typeof (stats as Record<string, unknown>)['count'] === 'number'
+                ? (stats as Record<string, unknown>)['count'] as number
+                : 0;
+        result[modelName] = count;
+    }
+    return result;
+}

--- a/tcode/alpha_control_center/src/tests/ux_systemmonitor_breakdown.spec.ts
+++ b/tcode/alpha_control_center/src/tests/ux_systemmonitor_breakdown.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * Phase 14.2 UX Tests: SystemMonitor SignalPanel breakdown rendering
+ *
+ * Regression guard for React error #31:
+ *   Object with keys {by_chop_regime, by_model, by_score_bin, ...} rendered as React child.
+ *
+ * Tests:
+ *   1. New Phase-14 shape renders per-model VitalsCard entries with numeric values
+ *   2. Old pre-Phase-14 shape {SENTIMENT: N, MACRO: N} renders fallback card — no crash
+ *   3. Missing breakdown (500 / empty) renders fallback card — no crash
+ *   4. No console errors (React error #31) in any of the above cases
+ */
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:5173';
+
+// ── Mock payloads ──────────────────────────────────────────────────────────────
+
+const NEW_BREAKDOWN = {
+    attribution: {
+        by_model: {
+            '30d': {
+                SENTIMENT: { count: 42, avg_confidence: 0.78, avg_selection_score: 0.85 },
+                MACRO: { count: 17, avg_confidence: 0.65, avg_selection_score: null },
+                CONTRARIAN: { count: 5, avg_confidence: 0.55, avg_selection_score: 0.60 },
+            },
+        },
+        by_chop_regime: {},
+        by_score_bin: {},
+        windows: ['30d'],
+        generated_at: '2026-04-14T10:00:00Z',
+        note: 'rolling attribution',
+    },
+};
+
+const OLD_BREAKDOWN = { SENTIMENT: 123, MACRO: 45 };
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+async function setupBaseStubs(page: import('@playwright/test').Page) {
+    // Stub everything except /api/metrics/signals/breakdown so tests can set that independently
+    await page.route('**/api/metrics/signals', async route => {
+        await route.fulfill({ json: [5, 3, 7, 4, 6], status: 200 });
+    });
+    await page.route('**/api/metrics/vitals', async route => {
+        await route.fulfill({ json: { total_signals: 1234, uptime_hours: 48 }, status: 200 });
+    });
+    await page.route('**/api/signals/all', async route => {
+        await route.fulfill({ json: [], status: 200 });
+    });
+    await page.route('**/api/**', async route => {
+        const url = route.request().url();
+        if (url.includes('/api/metrics/signals/breakdown')) {
+            // let caller set this
+            await route.continue();
+        } else {
+            await route.fulfill({ json: {}, status: 200 });
+        }
+    });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+test.describe('Phase 14.2: SignalPanel breakdown rendering', () => {
+
+    test('new attribution shape renders per-model VitalsCard entries with numeric values', async ({ page }) => {
+        const errors: string[] = [];
+        page.on('console', msg => {
+            if (msg.type() === 'error') errors.push(msg.text());
+        });
+
+        await page.route('**/api/metrics/signals/breakdown', async route => {
+            await route.fulfill({ json: NEW_BREAKDOWN, status: 200 });
+        });
+        await setupBaseStubs(page);
+        await page.goto(BASE);
+
+        // Wait for the SignalPanel to load
+        await page.waitForSelector('.sparkline-container, .vitals-grid', { timeout: 15000 });
+
+        // Assert that at least one VitalsCard with a known model name is rendered
+        // VitalsCards render their label as text inside the grid
+        const vitalsGrid = page.locator('.vitals-grid').first();
+        await expect(vitalsGrid).toBeVisible();
+
+        const gridText = await vitalsGrid.textContent();
+        expect(gridText).toMatch(/SENTIMENT|MACRO|CONTRARIAN/);
+
+        // Assert values are numeric (not "[object Object]")
+        const valueEls = vitalsGrid.locator('.vitals-value, [class*="value"]');
+        const count = await valueEls.count();
+        for (let i = 0; i < count; i++) {
+            const text = await valueEls.nth(i).textContent();
+            if (text) {
+                expect(text).not.toContain('[object');
+                expect(text).not.toContain('Object');
+            }
+        }
+
+        // No React error #31 in console
+        const reactErrors = errors.filter(e => e.includes('Minified React error') || e.includes('Error #31') || e.includes('Objects are not valid as a React child'));
+        expect(reactErrors).toHaveLength(0);
+    });
+
+    test('old flat shape {SENTIMENT: N, MACRO: N} renders fallback — no crash, no [object Object]', async ({ page }) => {
+        const errors: string[] = [];
+        page.on('console', msg => {
+            if (msg.type() === 'error') errors.push(msg.text());
+        });
+
+        await page.route('**/api/metrics/signals/breakdown', async route => {
+            await route.fulfill({ json: OLD_BREAKDOWN, status: 200 });
+        });
+        await setupBaseStubs(page);
+        await page.goto(BASE);
+
+        await page.waitForSelector('.vitals-grid', { timeout: 15000 });
+        const vitalsGrid = page.locator('.vitals-grid').first();
+        await expect(vitalsGrid).toBeVisible();
+
+        const gridText = await vitalsGrid.textContent();
+        // Must not render raw object representation
+        expect(gridText).not.toContain('[object');
+        expect(gridText).not.toContain('Object');
+
+        // No React error #31
+        const reactErrors = errors.filter(e => e.includes('Minified React error') || e.includes('Objects are not valid as a React child'));
+        expect(reactErrors).toHaveLength(0);
+    });
+
+    test('missing breakdown (500) renders fallback card — no crash', async ({ page }) => {
+        const errors: string[] = [];
+        page.on('console', msg => {
+            if (msg.type() === 'error') errors.push(msg.text());
+        });
+
+        await page.route('**/api/metrics/signals/breakdown', async route => {
+            await route.fulfill({ status: 500, body: 'Internal Server Error' });
+        });
+        await setupBaseStubs(page);
+        await page.goto(BASE);
+
+        await page.waitForSelector('.vitals-grid', { timeout: 15000 });
+        const vitalsGrid = page.locator('.vitals-grid').first();
+        await expect(vitalsGrid).toBeVisible();
+
+        // No React error #31
+        const reactErrors = errors.filter(e => e.includes('Minified React error') || e.includes('Objects are not valid as a React child'));
+        expect(reactErrors).toHaveLength(0);
+    });
+
+    test('no RootErrorBoundary "Dashboard render error" banner in any scenario', async ({ page }) => {
+        await page.route('**/api/metrics/signals/breakdown', async route => {
+            await route.fulfill({ json: NEW_BREAKDOWN, status: 200 });
+        });
+        await setupBaseStubs(page);
+        await page.goto(BASE);
+
+        await page.waitForTimeout(3000); // let all fetches settle
+
+        // RootErrorBoundary renders a banner with "reload" text on crash
+        const errorBanner = page.locator('text=Dashboard render error');
+        await expect(errorBanner).not.toBeVisible();
+    });
+});


### PR DESCRIPTION
## Problem

Phase 14 changed `/api/metrics/signals/breakdown` from a flat `{MODEL: count}` map to a nested attribution object. The old consumer in `SystemMonitor.tsx` called `Object.entries(breakdown)` which yielded `[["attribution", {...big obj...}]]` and passed the attribution object directly as `value` to VitalsCard — a non-primitive React child — causing **React Minified Error #31**. The RootErrorBoundary (Phase 14.1) caught the crash but the root cause remained.

## Fix

**`SystemMonitor.tsx`** — replaced the broken inline `Object.entries(breakdown)` with `parseBreakdownByModel(breakdown)` from a new helper.

**`src/lib/breakdown_parser.ts`** — pure helper that navigates `attribution.by_model['30d']` with runtime `typeof` guards at every step, returns flat `{ [modelName]: count }`. Falls back to `{}` (renders "Signals 30d: 0" fallback card) if shape is unrecognised. Emits `console.warn('[SIGNALPANEL-UNEXPECTED-SHAPE]...')` on unexpected shapes for early drift detection.

Guard rules:
- No `as number` casts on API data — every value verified with `typeof x === 'number'`
- `null / undefined / {} / old shape / partial new shape` all return `{}` — zero crashes
- Non-numeric `count` fields coerce to `0`

## Other breakdown API consumers

`grep -rn "/api/metrics/signals/breakdown|by_chop_regime|by_model\[" alpha_control_center/src` → **No other consumers found.** Only `SystemMonitor.tsx:214` fetches this endpoint.

## Tests

**Vitest unit** — `src/lib/breakdown_parser.test.ts` (11 tests, all passing):
- New Phase-14 shape → correct per-model counts
- `null`, `undefined`, `{}`, old flat shape → `{}`
- Missing `attribution.by_model` → `{}`; missing window → `{}`
- Missing/non-numeric `count` field → `0`, never an object

**Playwright e2e** — `src/tests/ux_systemmonitor_breakdown.spec.ts` (4 tests):
- New attribution shape renders named VitalsCards, no `[object Object]`, no console error #31
- Old flat shape renders fallback — no crash
- 500 error renders fallback — no crash
- No RootErrorBoundary banner in any scenario

## Open PR (after `gh auth login`)

```bash
gh pr create \
  --repo franksbaz/gpfiles \
  --head mmucklo:fix/stabilization-phase-14-2-signalpanel-breakdown \
  --base master \
  --title "fix(ui): Stabilization Phase 14.2 — SignalPanel breakdown React error #31" \
  --body-file /tmp/pr_body.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
