### PR TITLE
fix(ui): Stabilization Phase 14.4 — SYS badge click opens SystemHealth modal

### DIFF
--- a/tcode/alpha_control_center/src/App.tsx
+++ b/tcode/alpha_control_center/src/App.tsx
@@ -50,7 +50,7 @@ export class RootErrorBoundary extends Component<{ children: ReactNode }, EBStat
 }
 import IntegrityStatus from './components/IntegrityStatus';
 import HelpPanel from './components/HelpPanel';
-import { SystemHealthBadge, type HealthSummary } from './components/SystemHealthPanel';
+import SystemHealthPanel, { SystemHealthBadge, type HealthSummary } from './components/SystemHealthPanel';
 import { Shield, Menu, Home, Share2, Map, HelpCircle } from 'lucide-react';
 import Dashboard from './pages/Dashboard';
 import Architecture from './pages/Architecture';
@@ -78,6 +78,7 @@ function App() {
   const [notionalToast, setNotionalToast] = useState<string>('');
   const [notionalPendingRestart, setNotionalPendingRestart] = useState(false);
   const [showNotionalDrill, setShowNotionalDrill] = useState(false);
+  const [showHealthModal, setShowHealthModal] = useState(false);
 
   const brokerStatus = useDataFetching('/api/broker/status', 10000, null);
 
@@ -184,6 +185,14 @@ function App() {
 
   const handleIntegrityChange = useCallback((isRed: boolean) => {
     setIntegrityRed(isRed);
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setShowHealthModal(false);
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
   }, []);
 
   return (
@@ -364,13 +373,40 @@ function App() {
             </div>
           )}
         </div>
+
+        {/* System Health modal drill-down — Phase 14.4 */}
+        {showHealthModal && (
+          <div
+            className="modal-overlay"
+            onClick={() => setShowHealthModal(false)}
+            role="dialog"
+            aria-modal="true"
+            aria-label="System Health Details"
+          >
+            <div
+              className="modal-card nav-drill"
+              style={{ maxWidth: '680px', width: '90%', maxHeight: '80vh', overflowY: 'auto' }}
+              onClick={e => e.stopPropagation()}
+            >
+              <div className="modal-header">
+                <span className="modal-title">SYSTEM HEALTH — PER-COMPONENT DETAIL</span>
+                <button className="modal-close" onClick={() => setShowHealthModal(false)} aria-label="Close">✕</button>
+              </div>
+              <SystemHealthPanel onHealthChange={setHealthSummary} />
+            </div>
+          </div>
+        )}
+
         <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
             {/* Integrity Status — three traffic lights */}
             <IntegrityStatus onStatusChange={handleIntegrityChange} />
 
             {/* System health badge — Phase 13.6: always visible, goes red on component outage */}
+            {/* Phase 14.4: onClick opens SystemHealthPanel modal drill-down */}
             <SystemHealthBadge
               summary={healthSummary}
+              onClick={() => setShowHealthModal(true)}
+              ariaExpanded={showHealthModal}
             />
 
             {/* Execution mode banner — always visible, never hidden.

--- a/tcode/alpha_control_center/src/components/SystemHealthPanel.tsx
+++ b/tcode/alpha_control_center/src/components/SystemHealthPanel.tsx
@@ -424,9 +424,10 @@ export interface HealthSummary {
 export interface SystemHealthBadgeProps {
   summary: HealthSummary | null;
   onClick?: () => void;
+  ariaExpanded?: boolean;
 }
 
-export const SystemHealthBadge = ({ summary, onClick }: SystemHealthBadgeProps) => {
+export const SystemHealthBadge = ({ summary, onClick, ariaExpanded }: SystemHealthBadgeProps) => {
   if (!summary) return null;
 
   const { total, ok, degraded, error } = summary;
@@ -452,12 +453,10 @@ export const SystemHealthBadge = ({ summary, onClick }: SystemHealthBadgeProps) 
       style={{ background: bg, border: `1px solid ${border}` }}
       onClick={onClick}
       aria-label={`System health: ${label}`}
+      aria-expanded={ariaExpanded}
+      aria-haspopup="dialog"
       data-testid="system-health-badge"
-      title={allOk
-        ? `All ${total} components healthy`
-        : anyError
-        ? `${error} component${error > 1 ? 's' : ''} in ERROR state — click for details`
-        : `${degraded} component${degraded > 1 ? 's' : ''} degraded — click for details`}
+      title="System Health — click for per-component detail"
     >
       {label}
     </button>

--- a/tcode/alpha_control_center/src/components/SystemHealthPanel.tsx
+++ b/tcode/alpha_control_center/src/components/SystemHealthPanel.tsx
@@ -431,7 +431,6 @@ export const SystemHealthBadge = ({ summary, onClick, ariaExpanded }: SystemHeal
   if (!summary) return null;
 
   const { total, ok, degraded, error } = summary;
-  const allOk = error === 0 && degraded === 0;
   const anyError = error > 0;
 
   let bg = '#1a7f37';

--- a/tcode/alpha_control_center/src/pages/Dashboard.tsx
+++ b/tcode/alpha_control_center/src/pages/Dashboard.tsx
@@ -4872,6 +4872,8 @@ const RejectionAuditFeed = ({ onOpenPanel }: { onOpenPanel: () => void }) => {
                     fontSize: '0.72rem',
                 }}
                 aria-expanded={open}
+                aria-label={`${open ? 'Collapse' : 'Expand'} recent rejection events`}
+                title="Toggle recent rejection events"
             >
                 <span style={{ transform: open ? 'rotate(90deg)' : 'none', transition: 'transform 0.15s', fontSize: '0.6rem' }}>▶</span>
                 <span>Recent rejection events ({events.length})</span>

--- a/tcode/alpha_control_center/src/tests/ux_sys_badge_click.spec.ts
+++ b/tcode/alpha_control_center/src/tests/ux_sys_badge_click.spec.ts
@@ -1,0 +1,253 @@
+/**
+ * Phase 14.4 UX Tests: SYS badge click opens SystemHealthPanel modal
+ *
+ * Tests:
+ *   1. Clicking "SYS N/N ok" badge opens a dialog with role="dialog" within 500ms
+ *   2. Dialog contains per-component rows (heartbeat LEDs + names)
+ *   3. Pressing Esc closes the dialog
+ *   4. Reopening then clicking the backdrop closes the dialog
+ *   5. No console errors throughout
+ */
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:5173';
+
+// ── Mock heartbeats payload ────────────────────────────────────────────────────
+
+const MOCK_HEARTBEATS = {
+    ts: new Date().toISOString(),
+    components: {
+        publisher: {
+            status: 'ok',
+            last_ts: new Date(Date.now() - 5000).toISOString(),
+            age_sec: 5,
+            expected_max_age_sec: 30,
+            pid: 12345,
+            uptime_sec: 3600,
+            detail: null,
+        },
+        intel_refresh: {
+            status: 'ok',
+            last_ts: new Date(Date.now() - 10000).toISOString(),
+            age_sec: 10,
+            expected_max_age_sec: 300,
+            pid: 12346,
+            uptime_sec: 3500,
+            detail: null,
+        },
+        options_chain_api: {
+            status: 'ok',
+            last_ts: new Date(Date.now() - 8000).toISOString(),
+            age_sec: 8,
+            expected_max_age_sec: 60,
+            pid: 12347,
+            uptime_sec: 3400,
+            detail: null,
+        },
+        premarket: {
+            status: 'ok',
+            last_ts: new Date(Date.now() - 3000).toISOString(),
+            age_sec: 3,
+            expected_max_age_sec: 600,
+            pid: null,
+            uptime_sec: null,
+            detail: null,
+        },
+        congress_trades: {
+            status: 'ok',
+            last_ts: new Date(Date.now() - 60000).toISOString(),
+            age_sec: 60,
+            expected_max_age_sec: 3600,
+            pid: null,
+            uptime_sec: null,
+            detail: null,
+        },
+        correlation_regime: {
+            status: 'ok',
+            last_ts: new Date(Date.now() - 120000).toISOString(),
+            age_sec: 120,
+            expected_max_age_sec: 900,
+            pid: null,
+            uptime_sec: null,
+            detail: null,
+        },
+        macro_regime: {
+            status: 'ok',
+            last_ts: new Date(Date.now() - 90000).toISOString(),
+            age_sec: 90,
+            expected_max_age_sec: 900,
+            pid: null,
+            uptime_sec: null,
+            detail: null,
+        },
+        engine_subscriber: {
+            status: 'ok',
+            last_ts: new Date(Date.now() - 4000).toISOString(),
+            age_sec: 4,
+            expected_max_age_sec: 30,
+            pid: 12348,
+            uptime_sec: 3600,
+            detail: null,
+        },
+        engine_ibkr_status: {
+            status: 'ok',
+            last_ts: new Date(Date.now() - 6000).toISOString(),
+            age_sec: 6,
+            expected_max_age_sec: 30,
+            pid: 12349,
+            uptime_sec: 3590,
+            detail: null,
+        },
+    },
+};
+
+// ── Shared route setup ─────────────────────────────────────────────────────────
+
+async function setupStubs(page: import('@playwright/test').Page) {
+    await page.route('**/api/system/heartbeats', async route => {
+        // Only stub the base endpoint; let sparkline requests 404 naturally
+        if (!route.request().url().includes('/sparkline') && !route.request().url().includes('/restart')) {
+            await route.fulfill({ json: MOCK_HEARTBEATS, status: 200 });
+        } else {
+            await route.continue();
+        }
+    });
+    await page.route('**/api/system/heartbeats/**', async route => {
+        await route.fulfill({ json: [], status: 200 });
+    });
+    await page.route('**/api/**', async route => {
+        await route.fulfill({ json: {}, status: 200 });
+    });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+test.describe('Phase 14.4: SYS badge click opens SystemHealthPanel modal', () => {
+
+    test('clicking SYS badge opens dialog with role=dialog within 500ms', async ({ page }) => {
+        const errors: string[] = [];
+        page.on('console', msg => {
+            if (msg.type() === 'error') errors.push(msg.text());
+        });
+
+        await setupStubs(page);
+        await page.goto(BASE);
+
+        // Wait for the badge to appear — it renders once healthSummary arrives
+        const badge = page.locator('[data-testid="system-health-badge"]');
+        await expect(badge).toBeVisible({ timeout: 10000 });
+
+        // Click the badge
+        const clickTime = Date.now();
+        await badge.click();
+
+        // Dialog must appear within 500ms
+        const dialog = page.locator('[role="dialog"][aria-label="System Health Details"]');
+        await expect(dialog).toBeVisible({ timeout: 500 });
+        expect(Date.now() - clickTime).toBeLessThan(500);
+
+        // No console errors
+        const criticalErrors = errors.filter(e =>
+            e.includes('Minified React error') ||
+            e.includes('Objects are not valid as a React child') ||
+            e.includes('is not a function')
+        );
+        expect(criticalErrors).toHaveLength(0);
+    });
+
+    test('dialog contains per-component rows with LED indicators and names', async ({ page }) => {
+        await setupStubs(page);
+        await page.goto(BASE);
+
+        const badge = page.locator('[data-testid="system-health-badge"]');
+        await expect(badge).toBeVisible({ timeout: 10000 });
+        await badge.click();
+
+        const dialog = page.locator('[role="dialog"][aria-label="System Health Details"]');
+        await expect(dialog).toBeVisible({ timeout: 500 });
+
+        // At least one sph-row (component row) must be present in the modal
+        const componentRows = dialog.locator('[data-testid^="sph-row-"]');
+        await expect(componentRows.first()).toBeVisible({ timeout: 5000 });
+        const rowCount = await componentRows.count();
+        expect(rowCount).toBeGreaterThan(0);
+    });
+
+    test('pressing Esc closes the dialog', async ({ page }) => {
+        await setupStubs(page);
+        await page.goto(BASE);
+
+        const badge = page.locator('[data-testid="system-health-badge"]');
+        await expect(badge).toBeVisible({ timeout: 10000 });
+        await badge.click();
+
+        const dialog = page.locator('[role="dialog"][aria-label="System Health Details"]');
+        await expect(dialog).toBeVisible({ timeout: 500 });
+
+        // Press Escape
+        await page.keyboard.press('Escape');
+        await expect(dialog).not.toBeVisible({ timeout: 1000 });
+    });
+
+    test('clicking backdrop closes the dialog', async ({ page }) => {
+        await setupStubs(page);
+        await page.goto(BASE);
+
+        const badge = page.locator('[data-testid="system-health-badge"]');
+        await expect(badge).toBeVisible({ timeout: 10000 });
+        await badge.click();
+
+        const dialog = page.locator('[role="dialog"][aria-label="System Health Details"]');
+        await expect(dialog).toBeVisible({ timeout: 500 });
+
+        // Click the overlay (top-left corner outside the card)
+        await page.mouse.click(5, 5);
+        await expect(dialog).not.toBeVisible({ timeout: 1000 });
+
+        // Reopen to verify badge still works after close
+        await badge.click();
+        await expect(dialog).toBeVisible({ timeout: 500 });
+    });
+
+    test('no console errors throughout open/close lifecycle', async ({ page }) => {
+        const errors: string[] = [];
+        page.on('console', msg => {
+            if (msg.type() === 'error') errors.push(msg.text());
+        });
+
+        await setupStubs(page);
+        await page.goto(BASE);
+
+        const badge = page.locator('[data-testid="system-health-badge"]');
+        await expect(badge).toBeVisible({ timeout: 10000 });
+
+        // Open
+        await badge.click();
+        const dialog = page.locator('[role="dialog"][aria-label="System Health Details"]');
+        await expect(dialog).toBeVisible({ timeout: 500 });
+
+        // Wait for panel data to settle
+        await page.waitForTimeout(500);
+
+        // Close via Esc
+        await page.keyboard.press('Escape');
+        await expect(dialog).not.toBeVisible({ timeout: 1000 });
+
+        // Reopen
+        await badge.click();
+        await expect(dialog).toBeVisible({ timeout: 500 });
+
+        // Close via backdrop
+        await page.mouse.click(5, 5);
+        await expect(dialog).not.toBeVisible({ timeout: 1000 });
+
+        const criticalErrors = errors.filter(e =>
+            e.includes('Minified React error') ||
+            e.includes('Objects are not valid as a React child') ||
+            e.includes('is not a function') ||
+            e.includes('TypeError') ||
+            e.includes('undefined is not')
+        );
+        expect(criticalErrors).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
# fix(ui): Stabilization Phase 14.4 — wire SYS badge click to SystemHealthPanel modal

## Summary

- **Root cause**: `SystemHealthBadge` in `App.tsx` was rendered without an `onClick` prop, so clicking the "SYS N/N ok" header badge was a no-op.
- **Fix**: Wired `onClick={() => setShowHealthModal(true)}` on the badge, added `showHealthModal` state, and rendered a `modal-overlay` containing `<SystemHealthPanel>` when the modal is open.
- **Accessibility**: Badge now has `aria-expanded`, `aria-haspopup="dialog"`, and `title="System Health — click for per-component detail"`. Modal has `role="dialog"`, `aria-modal="true"`, `aria-label="System Health Details"`. Esc key and backdrop click both close the modal.
- **Live updates**: The modal's `SystemHealthPanel` uses `onHealthChange={setHealthSummary}` so both the modal instance and the inline dashboard panel independently poll `/api/system/heartbeats` — no state collision.
- **a11y bonus fix**: The "Recent rejection events" collapse toggle button in the rejected signals card was missing a tooltip (caught by pre-push UX gate) — added `aria-label` and `title`.

## Files changed

| File | Change |
|---|---|
| `src/App.tsx` | Import `SystemHealthPanel`, add `showHealthModal` state, Esc handler, badge `onClick`/`ariaExpanded`, modal render |
| `src/components/SystemHealthPanel.tsx` | Add `ariaExpanded` prop, `aria-expanded`/`aria-haspopup` on button, static title, remove unused `allOk` |
| `src/pages/Dashboard.tsx` | Add `aria-label`/`title` to rejection-events toggle button (UX gate fix) |
| `src/tests/ux_sys_badge_click.spec.ts` | New Playwright spec: badge opens dialog, Esc closes, backdrop closes, no console errors |

## Test plan

- [x] UX gate passed (5/5 tests including `ux_every_hoverable_tooltipped`)
- [x] TypeScript: `tsc -b` clean, no errors
- [x] Production build: `npm run build` succeeds
- [ ] Manual: click "SYS N/N ok" badge → modal appears with per-component rows
- [ ] Manual: Esc key closes modal; backdrop click closes modal
- [ ] Manual: inline SystemHealthPanel on dashboard still updates independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)
