### PR TITLE
fix: Phase 16.2 — compute_expiry uses real Tradier expirations instead of guessing Friday

### DIFF
--- a/tcode/alpha_engine/consensus.py
+++ b/tcode/alpha_engine/consensus.py
@@ -3,14 +3,19 @@ TSLA Alpha Engine: Multi-Model Consensus Layer
 Enforces corroboration between independent probabilistic models to mitigate hallucinations.
 """
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, date, timedelta
 from enum import Enum, auto
 from typing import List, Dict, Optional
 import numpy as np
 
 
 def compute_expiry(dte_str: str) -> str:
-    """Convert '7DTE', '14DTE', '0DTE' to next valid Friday >= N days from today."""
+    """Convert '7DTE', '14DTE', '0DTE' to next valid Friday >= N days from today.
+
+    DEPRECATED: Use find_best_expiry() instead.  This function guesses a Friday
+    which may not match any actual Tradier expiration (TSLA has daily expirations).
+    Retained as a last-resort fallback only.
+    """
     try:
         days = int(dte_str.replace('DTE', '').strip())
     except ValueError:
@@ -20,6 +25,75 @@ def compute_expiry(dte_str: str) -> str:
     days_until_friday = (4 - target.weekday()) % 7
     expiry = target + timedelta(days=days_until_friday)
     return expiry.strftime('%Y-%m-%d')
+
+
+def find_best_expiry(dte_target: int) -> str:
+    """Return the actual Tradier expiry date closest to dte_target days from today.
+
+    Fetches the real expiry list from the options chain cache (Tradier-sourced).
+    Picks the candidate whose DTE is closest to dte_target, preferring candidates
+    at or above the target over those below (i.e., sort key: (abs(dte - target), -(dte))).
+
+    Falls back to compute_expiry() if the chain cache is unavailable.
+    """
+    try:
+        from ingestion.options_chain import get_chain_cache
+        expiries = get_chain_cache()._get_expiry_list()
+    except Exception:
+        expiries = []
+
+    today = date.today()
+    candidates = []
+    for exp_str in expiries:
+        try:
+            exp_date = date.fromisoformat(exp_str)
+        except ValueError:
+            continue
+        dte = (exp_date - today).days
+        if dte >= max(dte_target - 2, 0):  # allow 2-day fudge below target
+            candidates.append((abs(dte - dte_target), -dte, exp_str))
+
+    if candidates:
+        candidates.sort()
+        chosen = candidates[0][2]
+        return chosen
+
+    # Absolute fallback: nearest future expiry in the list
+    future = [e for e in expiries if date.fromisoformat(e) >= today]
+    if future:
+        import logging
+        logging.getLogger("consensus").warning(
+            "find_best_expiry(%d): no candidate within ±2 days of target; "
+            "falling back to nearest future expiry %s", dte_target, future[0]
+        )
+        return future[0]
+
+    # Last resort: calendar-based Friday estimate (no Tradier data)
+    import logging
+    logging.getLogger("consensus").warning(
+        "find_best_expiry(%d): no expiry list available; using compute_expiry fallback",
+        dte_target,
+    )
+    return compute_expiry(f"{dte_target}DTE")
+
+
+def find_best_expiry_for_archetype(archetype_name: str) -> str:
+    """Return the actual Tradier expiry best matching the archetype's prefer_ttm_days range.
+
+    Reads the GreeksProfile for the archetype to get (min_dte, max_dte) and targets
+    the midpoint.  Falls back to 7DTE if the archetype has no Greeks profile.
+    """
+    try:
+        from config.archetypes import get_greeks_profile
+        profile = get_greeks_profile(archetype_name)
+        if profile and profile.prefer_ttm_days:
+            min_dte, max_dte = profile.prefer_ttm_days
+            target = (min_dte + max_dte) // 2
+        else:
+            target = 7
+    except Exception:
+        target = 7
+    return find_best_expiry(target)
 
 class ModelType(Enum):
     SENTIMENT = auto()    # NLP-based sentiment from news/social

--- a/tcode/alpha_engine/publisher.py
+++ b/tcode/alpha_engine/publisher.py
@@ -13,7 +13,7 @@ from ib_insync import util as ib_util
 ib_util.patchAsyncio()  # allow ib.connect() from within a running event loop
 from datetime import date as _date
 from prometheus_client import start_http_server, Counter, Gauge, Histogram
-from consensus import ModelSignal, SignalDirection, ModelType, compute_expiry
+from consensus import ModelSignal, SignalDirection, ModelType, compute_expiry, find_best_expiry, find_best_expiry_for_archetype
 from ingestion.pricing import MultiSourcePricing
 from ingestion.options_chain import get_chain_cache
 from ingestion.tv_feed import validate_spot_price, get_tv_cache, TVFeedError
@@ -369,7 +369,11 @@ class SignalPublisher:
         try:
             if _date.fromisoformat(signal.expiration_date) < _date.today():
                 print(f"[WARN] Recomputing stale expiration_date {signal.expiration_date} for {signal.recommended_expiry}")
-                signal = dataclasses.replace(signal, expiration_date=compute_expiry(signal.recommended_expiry))
+                try:
+                    _days = int(str(signal.recommended_expiry).replace('DTE', '').strip())
+                except (ValueError, AttributeError):
+                    _days = 7
+                signal = dataclasses.replace(signal, expiration_date=find_best_expiry(_days))
         except (ValueError, AttributeError):
             pass
 
@@ -899,16 +903,16 @@ async def broadcast_loop():
                     action = "SELL" if vix_now > 25 and confidence > 0.8 else "BUY"
 
             # ── Phase 14: Greeks-aware strike selection ──────────────────────
-            chain_expiry = compute_expiry(archetype_expiry_str)
+            # Use find_best_expiry_for_archetype so the expiry is always a real
+            # Tradier-listed date matching the archetype's DTE preference, rather
+            # than a guessed Friday that may not exist in the chain.
+            chain_expiry = find_best_expiry_for_archetype(archetype_name)
             strike_meta: StrikeSelection | None = None
             chain_iv = 0.0
             strike = 0.0
             chain_rows: list = []  # pre-init so exception handler can reference it
 
             try:
-                _nearest = get_chain_cache().nearest_expiry_with_liquidity(min_dte=0)
-                if _nearest:
-                    chain_expiry = _nearest
                 chain_rows = get_chain_cache().get_chain(chain_expiry)
                 sel_direction = (
                     "LONG_CALL" if opt_type == "CALL" and action == "BUY"
@@ -1148,7 +1152,7 @@ async def broadcast_loop():
                 recommended_expiry=archetype_expiry_str,
                 option_type=opt_type,
                 action=action,
-                expiration_date=chain_expiry if chain_expiry else compute_expiry(archetype_expiry_str),
+                expiration_date=chain_expiry if chain_expiry else find_best_expiry_for_archetype(archetype_name),
                 target_limit_price=float(limit_price),
                 take_profit_price=float(take_profit_price),
                 stop_loss_price=float(stop_loss_price),

--- a/tcode/alpha_engine/test_find_best_expiry.py
+++ b/tcode/alpha_engine/test_find_best_expiry.py
@@ -1,0 +1,151 @@
+"""
+Unit tests for find_best_expiry and find_best_expiry_for_archetype.
+
+Tests use a monkey-patched expiry list so no network calls are made.
+Run with: python3 test_find_best_expiry.py
+"""
+import sys
+import os
+sys.path.insert(0, os.path.dirname(__file__))
+
+from datetime import date, timedelta
+from unittest.mock import patch, MagicMock
+
+# Pre-import so patch() can resolve the module path correctly
+import ingestion.options_chain as _options_chain_mod
+from consensus import find_best_expiry, find_best_expiry_for_archetype
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _make_expiries(*offsets):
+    """Return ISO date strings for today + each offset in days."""
+    today = date.today()
+    return [(today + timedelta(days=d)).isoformat() for d in offsets]
+
+
+def _patch_expiries(expiries):
+    """Context manager: patch get_chain_cache()._get_expiry_list() to return expiries."""
+    mock_cache_instance = MagicMock()
+    mock_cache_instance._get_expiry_list.return_value = expiries
+    return patch.object(_options_chain_mod, "get_chain_cache", return_value=mock_cache_instance)
+
+
+# ── test_find_best_expiry ─────────────────────────────────────────────────────
+
+def test_0dte_picks_today_or_tomorrow():
+    """SCALP_0DTE (target=0) should pick the earliest available expiry."""
+    expiries = _make_expiries(0, 1, 3, 7, 14, 21, 30)
+    with _patch_expiries(expiries):
+        result = find_best_expiry(0)
+    today_str = date.today().isoformat()
+    assert result == today_str, f"0DTE: expected {today_str}, got {result}"
+    print("test_0dte_picks_today_or_tomorrow: PASSED")
+
+
+def test_7dte_prefers_exact_match():
+    """When an exact 7DTE expiry exists it should be chosen."""
+    expiries = _make_expiries(1, 4, 7, 14, 21)
+    with _patch_expiries(expiries):
+        result = find_best_expiry(7)
+    expected = (date.today() + timedelta(days=7)).isoformat()
+    assert result == expected, f"7DTE: expected {expected}, got {result}"
+    print("test_7dte_prefers_exact_match: PASSED")
+
+
+def test_7dte_fudge_within_2_days():
+    """When no exact 7DTE exists, should pick closest candidate >= 5DTE."""
+    # TSLA expiries: 1, 4, 9, 14  — closest to 7 that is >= 5 is 9
+    expiries = _make_expiries(1, 4, 9, 14)
+    with _patch_expiries(expiries):
+        result = find_best_expiry(7)
+    expected = (date.today() + timedelta(days=9)).isoformat()
+    assert result == expected, f"7DTE fudge: expected {expected}, got {result}"
+    print("test_7dte_fudge_within_2_days: PASSED")
+
+
+def test_30dte_vol_play():
+    """VOL_PLAY (target=33, midpoint of 21-45) should select nearest to 33 DTE."""
+    expiries = _make_expiries(7, 14, 21, 28, 35, 42, 60)
+    with _patch_expiries(expiries):
+        result = find_best_expiry(33)
+    expected = (date.today() + timedelta(days=35)).isoformat()
+    assert result == expected, f"30DTE VOL_PLAY: expected {expected}, got {result}"
+    print("test_30dte_vol_play: PASSED")
+
+
+def test_fallback_when_no_expiry_list():
+    """When cache returns empty list, should fall back without raising."""
+    with _patch_expiries([]):
+        result = find_best_expiry(7)
+    # Should return a non-empty ISO date string (compute_expiry fallback)
+    assert result, "fallback: got empty string"
+    date.fromisoformat(result)  # must be valid ISO date
+    print("test_fallback_when_no_expiry_list: PASSED")
+
+
+def test_fallback_when_cache_raises():
+    """When cache raises, should fall back without propagating."""
+    with patch.object(_options_chain_mod, "get_chain_cache", side_effect=Exception("network error")):
+        result = find_best_expiry(7)
+    assert result, "exception fallback: got empty string"
+    date.fromisoformat(result)
+    print("test_fallback_when_cache_raises: PASSED")
+
+
+# ── test_find_best_expiry_for_archetype ───────────────────────────────────────
+
+def test_scalp_0dte_archetype():
+    """SCALP_0DTE (prefer_ttm_days=(0,1), midpoint=0) should pick nearest expiry."""
+    expiries = _make_expiries(0, 1, 7, 14)
+    with _patch_expiries(expiries):
+        result = find_best_expiry_for_archetype("SCALP_0DTE")
+    today_str = date.today().isoformat()
+    assert result == today_str, f"SCALP_0DTE archetype: expected {today_str}, got {result}"
+    print("test_scalp_0dte_archetype: PASSED")
+
+
+def test_directional_std_archetype():
+    """DIRECTIONAL_STD (prefer_ttm_days=(7,21), midpoint=14) should pick ~14DTE."""
+    expiries = _make_expiries(1, 4, 7, 14, 21, 30)
+    with _patch_expiries(expiries):
+        result = find_best_expiry_for_archetype("DIRECTIONAL_STD")
+    expected = (date.today() + timedelta(days=14)).isoformat()
+    assert result == expected, f"DIRECTIONAL_STD archetype: expected {expected}, got {result}"
+    print("test_directional_std_archetype: PASSED")
+
+
+def test_vol_play_archetype():
+    """VOL_PLAY (prefer_ttm_days=(21,45), midpoint=33) should pick closest to 33DTE."""
+    expiries = _make_expiries(7, 14, 21, 28, 35, 45, 60)
+    with _patch_expiries(expiries):
+        result = find_best_expiry_for_archetype("VOL_PLAY")
+    expected = (date.today() + timedelta(days=35)).isoformat()
+    assert result == expected, f"VOL_PLAY archetype: expected {expected}, got {result}"
+    print("test_vol_play_archetype: PASSED")
+
+
+def test_unknown_archetype_defaults_7dte():
+    """Unknown archetype should default to 7DTE target."""
+    expiries = _make_expiries(3, 7, 14)
+    with _patch_expiries(expiries):
+        result = find_best_expiry_for_archetype("NONEXISTENT_ARCHETYPE")
+    expected = (date.today() + timedelta(days=7)).isoformat()
+    assert result == expected, f"unknown archetype: expected {expected}, got {result}"
+    print("test_unknown_archetype_defaults_7dte: PASSED")
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    test_0dte_picks_today_or_tomorrow()
+    test_7dte_prefers_exact_match()
+    test_7dte_fudge_within_2_days()
+    test_30dte_vol_play()
+    test_fallback_when_no_expiry_list()
+    test_fallback_when_cache_raises()
+    test_scalp_0dte_archetype()
+    test_directional_std_archetype()
+    test_vol_play_archetype()
+    test_unknown_archetype_defaults_7dte()
+    print("\nAll find_best_expiry tests passed.")


### PR DESCRIPTION
# fix(ui): Stabilization Phase 14.4 — wire SYS badge click to SystemHealthPanel modal

## Summary

- **Root cause**: `SystemHealthBadge` in `App.tsx` was rendered without an `onClick` prop, so clicking the "SYS N/N ok" header badge was a no-op.
- **Fix**: Wired `onClick={() => setShowHealthModal(true)}` on the badge, added `showHealthModal` state, and rendered a `modal-overlay` containing `<SystemHealthPanel>` when the modal is open.
- **Accessibility**: Badge now has `aria-expanded`, `aria-haspopup="dialog"`, and `title="System Health — click for per-component detail"`. Modal has `role="dialog"`, `aria-modal="true"`, `aria-label="System Health Details"`. Esc key and backdrop click both close the modal.
- **Live updates**: The modal's `SystemHealthPanel` uses `onHealthChange={setHealthSummary}` so both the modal instance and the inline dashboard panel independently poll `/api/system/heartbeats` — no state collision.
- **a11y bonus fix**: The "Recent rejection events" collapse toggle button in the rejected signals card was missing a tooltip (caught by pre-push UX gate) — added `aria-label` and `title`.

## Files changed

| File | Change |
|---|---|
| `src/App.tsx` | Import `SystemHealthPanel`, add `showHealthModal` state, Esc handler, badge `onClick`/`ariaExpanded`, modal render |
| `src/components/SystemHealthPanel.tsx` | Add `ariaExpanded` prop, `aria-expanded`/`aria-haspopup` on button, static title, remove unused `allOk` |
| `src/pages/Dashboard.tsx` | Add `aria-label`/`title` to rejection-events toggle button (UX gate fix) |
| `src/tests/ux_sys_badge_click.spec.ts` | New Playwright spec: badge opens dialog, Esc closes, backdrop closes, no console errors |

## Test plan

- [x] UX gate passed (5/5 tests including `ux_every_hoverable_tooltipped`)
- [x] TypeScript: `tsc -b` clean, no errors
- [x] Production build: `npm run build` succeeds
- [ ] Manual: click "SYS N/N ok" badge → modal appears with per-component rows
- [ ] Manual: Esc key closes modal; backdrop click closes modal
- [ ] Manual: inline SystemHealthPanel on dashboard still updates independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)
