### PR TITLE
fix: Phase 18.1 — Execute button error surfacing + expiry validation + market state label

### DIFF
--- a/tcode/alpha_control_center/src/components/TradeApprovalQueue.css
+++ b/tcode/alpha_control_center/src/components/TradeApprovalQueue.css
@@ -395,6 +395,16 @@
   color: #6e7681;
 }
 
+.proposal-status-overlay.execute_failed {
+  background: rgba(139, 26, 26, 0.12);
+  color: #f85149;
+}
+
+.proposal-card.execute_failed {
+  border-color: #8b1a1a;
+  opacity: 0.8;
+}
+
 /* Empty state */
 .taq-empty {
   text-align: center;

--- a/tcode/alpha_control_center/src/components/TradeApprovalQueue.tsx
+++ b/tcode/alpha_control_center/src/components/TradeApprovalQueue.tsx
@@ -108,9 +108,10 @@ interface CardProps {
   onExecute: (id: string, qty: number) => Promise<void>;
   onSkip: (id: string) => Promise<void>;
   onAdjust: (id: string, qty: number) => Promise<void>;
+  onToast: (msg: string, type: 'success' | 'error') => void;
 }
 
-const ProposalCard: React.FC<CardProps> = ({ proposal: p, isLive, onExecute, onSkip, onAdjust }) => {
+const ProposalCard: React.FC<CardProps> = ({ proposal: p, isLive, onExecute, onSkip, onAdjust, onToast }) => {
   const [showAdjust, setShowAdjust] = useState(false);
   const [adjustQty, setAdjustQty] = useState(p.quantity);
   const [executing, setExecuting] = useState(false);
@@ -155,6 +156,9 @@ const ProposalCard: React.FC<CardProps> = ({ proposal: p, isLive, onExecute, onS
     setExecuting(true);
     try {
       await onExecute(p.id, p.quantity);
+      onToast(`Order submitted — ${p.strategy} ${buildContractLabel(p.legs)}`, 'success');
+    } catch (err) {
+      onToast(`Execute failed: ${String(err)}`, 'error');
     } finally {
       setExecuting(false);
     }
@@ -164,6 +168,9 @@ const ProposalCard: React.FC<CardProps> = ({ proposal: p, isLive, onExecute, onS
     setExecuting(true);
     try {
       await onAdjust(p.id, adjustQty);
+      onToast(`Order submitted (adjusted) — ${p.strategy} ${buildContractLabel(p.legs)}`, 'success');
+    } catch (err) {
+      onToast(`Execute failed: ${String(err)}`, 'error');
     } finally {
       setExecuting(false);
       setShowAdjust(false);
@@ -178,6 +185,7 @@ const ProposalCard: React.FC<CardProps> = ({ proposal: p, isLive, onExecute, onS
   const isPending = p.status === 'pending';
   const isExecuted = p.status === 'executed' || p.status === 'adjusted';
   const isExpired = p.status === 'expired';
+  const isFailed = p.status === 'execute_failed';
 
   const direction = p.direction?.toUpperCase();
   const directionClass = direction === 'BULLISH' ? 'bullish' : direction === 'BEARISH' ? 'bearish' : 'neutral';
@@ -346,6 +354,9 @@ const ProposalCard: React.FC<CardProps> = ({ proposal: p, isLive, onExecute, onS
       {isExpired && (
         <div className="proposal-status-overlay expired">EXPIRED</div>
       )}
+      {isFailed && (
+        <div className="proposal-status-overlay execute_failed">✗ FAILED</div>
+      )}
     </div>
   );
 };
@@ -361,6 +372,8 @@ const TradeApprovalQueue: React.FC<TAQProps> = ({ brokerMode }) => {
   const [newIds, setNewIds] = useState<Set<string>>(new Set());
   const [filter, setFilter] = useState<FilterMode>('all');
   const [age, setAge] = useState('');
+  const [toast, setToast] = useState<{ msg: string; type: 'success' | 'error' } | null>(null);
+  const toastTimerRef = useRef<number>(0);
   const prevIds = useRef<Set<string>>(new Set());
 
   const isLive = brokerMode === 'IBKR_LIVE';
@@ -399,13 +412,26 @@ const TradeApprovalQueue: React.FC<TAQProps> = ({ brokerMode }) => {
     return () => clearInterval(t);
   }, [queueData?.updated_at]);
 
+  const showToast = (msg: string, type: 'success' | 'error') => {
+    setToast({ msg, type });
+    clearTimeout(toastTimerRef.current);
+    if (type === 'success') {
+      toastTimerRef.current = window.setTimeout(() => setToast(null), 5000);
+    }
+    // error toasts persist until dismissed
+  };
+
   const handleExecute = async (id: string, qty: number) => {
-    await fetch(`/api/trades/proposed/${id}/execute`, {
+    const resp = await fetch(`/api/trades/proposed/${id}/execute`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ quantity: qty }),
     });
+    const data = await resp.json().catch(() => ({}));
     fetchQueue();
+    if (!resp.ok || !data.ok) {
+      throw new Error(data.error || `HTTP ${resp.status}`);
+    }
   };
 
   const handleSkip = async (id: string) => {
@@ -414,12 +440,16 @@ const TradeApprovalQueue: React.FC<TAQProps> = ({ brokerMode }) => {
   };
 
   const handleAdjust = async (id: string, qty: number) => {
-    await fetch(`/api/trades/proposed/${id}/adjust`, {
+    const resp = await fetch(`/api/trades/proposed/${id}/adjust`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ quantity: qty }),
     });
+    const data = await resp.json().catch(() => ({}));
     fetchQueue();
+    if (!resp.ok || !data.ok) {
+      throw new Error(data.error || `HTTP ${resp.status}`);
+    }
   };
 
   const proposals = queueData?.proposals ?? [];
@@ -493,9 +523,34 @@ const TradeApprovalQueue: React.FC<TAQProps> = ({ brokerMode }) => {
               onExecute={handleExecute}
               onSkip={handleSkip}
               onAdjust={handleAdjust}
+              onToast={showToast}
             />
           </div>
         ))
+      )}
+
+      {/* Execute result toast */}
+      {toast && (
+        <div
+          data-testid="execute-toast"
+          role="alert"
+          style={{
+            position: 'fixed', bottom: '20px', right: '20px', zIndex: 9999,
+            backgroundColor: toast.type === 'success' ? '#1a7f37' : '#8b1a1a',
+            color: '#fff', padding: '0.75rem 1.2rem', borderRadius: '8px',
+            fontSize: '13px', fontWeight: 600, boxShadow: '0 2px 8px rgba(0,0,0,0.5)',
+            display: 'flex', alignItems: 'center', gap: '0.75rem', maxWidth: '360px',
+          }}
+        >
+          <span style={{ flex: 1 }}>{toast.msg}</span>
+          {toast.type === 'error' && (
+            <button
+              onClick={() => setToast(null)}
+              style={{ background: 'none', border: 'none', color: '#fff', cursor: 'pointer', fontSize: '16px', lineHeight: 1 }}
+              aria-label="Dismiss"
+            >✕</button>
+          )}
+        </div>
       )}
     </div>
   );

--- a/tcode/alpha_control_center/tests/ux_execute_error.spec.ts
+++ b/tcode/alpha_control_center/tests/ux_execute_error.spec.ts
@@ -6,6 +6,11 @@
  * - Proposal card shows "FAILED" overlay after execute error
  * - API success → green toast with confirmation
  * - Dismiss button clears error toast
+ *
+ * Route-interception pattern follows ux_cancel_close_controls.spec.ts:
+ *   - Abort all unmatched API calls to prevent the live server returning paused:true
+ *   - Seed localStorage pause state + mock pause-status so PauseOverlay never renders
+ *   - Register catch-all FIRST, specific routes after (LIFO: last wins)
  */
 
 import { test, expect, type Page } from '@playwright/test';
@@ -40,123 +45,147 @@ const QUEUE_RESPONSE = {
 
 const FAILED_PROPOSAL = { ...PENDING_PROPOSAL, status: 'execute_failed' };
 
-async function gotoAndWait(page: Page) {
-  await page.goto(BASE, { waitUntil: 'load' });
-  await page.waitForSelector('[data-testid="status-bar"]', { timeout: 15_000 });
-  await page.waitForTimeout(1500);
-}
-
-test('execute API 500 → red toast with error message', async ({ page }) => {
-  // Mock proposals endpoint to return a pending proposal
-  await page.route('**/api/trades/proposed', (route) => {
-    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(QUEUE_RESPONSE) });
+async function setupRoutes(
+  page: Page,
+  executeResult: { status: number; body: object },
+  queueProposals = QUEUE_RESPONSE,
+) {
+  // Bypass PauseOverlay: seed localStorage before page load.
+  await page.addInitScript(() => {
+    const active = { paused: false, unpause_until: null, remaining_sec: 0 };
+    localStorage.setItem('tsla_pause_state', JSON.stringify(active));
   });
 
-  // Mock execute endpoint to return 500 with error body
-  await page.route(`**/api/trades/proposed/${PROPOSAL_ID}/execute`, (route) => {
+  // Catch-all registered FIRST (lowest LIFO priority) — aborts unmocked calls
+  // so live server can't return paused:true and re-trigger the overlay.
+  await page.route('**/api/**', (route) => route.abort());
+
+  // Specific routes override the catch-all (LIFO: last-registered wins).
+  await page.route('**/api/system/pause-status', (route) =>
     route.fulfill({
-      status: 500,
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ paused: false, unpause_until: null, remaining_sec: 0 }),
+    })
+  );
+  await page.route('**/api/broker/status', (route) =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({ mode: 'IBKR_PAPER', broker: 'IBKR', connected: true }),
+    })
+  );
+  await page.route('**/api/account', (route) =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({
+        net_liquidation: 50000, cash_balance: 48000, unrealized_pnl: 0,
+        realized_pnl: 0, buying_power: 96000, equity_with_loan: 50000,
+        ts: new Date().toISOString(), source: 'IBKR_PAPER',
+      }),
+    })
+  );
+  await page.route('**/api/trades/proposed', (route) =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify(queueProposals),
+    })
+  );
+  await page.route(`**/api/trades/proposed/${PROPOSAL_ID}/execute`, (route) =>
+    route.fulfill({
+      status: executeResult.status,
       contentType: 'application/json',
-      body: JSON.stringify({ ok: false, error: 'expiry is empty — proposal missing expiration_date' }),
-    });
+      body: JSON.stringify(executeResult.body),
+    })
+  );
+}
+
+async function gotoAndWait(page: Page) {
+  await page.goto(BASE, { waitUntil: 'load' });
+  // Wait for PauseOverlay to detach (React re-renders after reading localStorage)
+  await page.locator('[data-testid="pause-overlay"]').waitFor({ state: 'detached', timeout: 10_000 });
+  await page.waitForSelector('[data-testid="status-bar"]', { timeout: 10_000 });
+  await page.waitForTimeout(1000);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test('execute API 500 → red toast with error message', async ({ page }) => {
+  await setupRoutes(page, {
+    status: 500,
+    body: { ok: false, error: 'expiry is empty — proposal missing expiration_date' },
   });
 
   await gotoAndWait(page);
 
-  // Find and click Execute button
   const execBtn = page.locator(`[data-testid="execute-btn-${PROPOSAL_ID}"]`);
-  await execBtn.waitFor({ timeout: 5000 });
-
-  // In paper mode there's no countdown, click fires immediately
+  await execBtn.waitFor({ timeout: 8000 });
   await execBtn.click();
 
-  // Red toast should appear
   const toast = page.locator('[data-testid="execute-toast"]');
-  await toast.waitFor({ timeout: 5000 });
+  await toast.waitFor({ timeout: 8000 });
   await expect(toast).toBeVisible();
 
   const toastText = await toast.textContent();
   expect(toastText).toContain('expiry is empty');
 
-  // Error toast has a dismiss button
-  const dismissBtn = toast.locator('button[aria-label="Dismiss"]');
-  await expect(dismissBtn).toBeVisible();
+  // Error toast has a dismiss button (not auto-dismissed)
+  await expect(toast.locator('button[aria-label="Dismiss"]')).toBeVisible();
 });
 
 test('dismiss button clears error toast', async ({ page }) => {
-  await page.route('**/api/trades/proposed', (route) => {
-    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(QUEUE_RESPONSE) });
-  });
-  await page.route(`**/api/trades/proposed/${PROPOSAL_ID}/execute`, (route) => {
-    route.fulfill({
-      status: 500,
-      contentType: 'application/json',
-      body: JSON.stringify({ ok: false, error: 'strike is 0 — proposal missing recommended_strike' }),
-    });
+  await setupRoutes(page, {
+    status: 500,
+    body: { ok: false, error: 'strike is 0 — proposal missing recommended_strike' },
   });
 
   await gotoAndWait(page);
 
   const execBtn = page.locator(`[data-testid="execute-btn-${PROPOSAL_ID}"]`);
-  await execBtn.waitFor({ timeout: 5000 });
+  await execBtn.waitFor({ timeout: 8000 });
   await execBtn.click();
 
   const toast = page.locator('[data-testid="execute-toast"]');
-  await toast.waitFor({ timeout: 5000 });
+  await toast.waitFor({ timeout: 8000 });
 
-  const dismissBtn = toast.locator('button[aria-label="Dismiss"]');
-  await dismissBtn.click();
+  await toast.locator('button[aria-label="Dismiss"]').click();
   await expect(toast).not.toBeVisible();
 });
 
 test('execute_failed status → FAILED overlay on proposal card', async ({ page }) => {
-  // Return proposal already in execute_failed state
-  const failedQueue = {
-    ...QUEUE_RESPONSE,
-    proposals: [FAILED_PROPOSAL],
-  };
-
-  await page.route('**/api/trades/proposed', (route) => {
-    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(failedQueue) });
-  });
+  await setupRoutes(
+    page,
+    { status: 200, body: { ok: true } }, // won't be called — proposal already failed
+    { ...QUEUE_RESPONSE, proposals: [FAILED_PROPOSAL] },
+  );
 
   await gotoAndWait(page);
 
   const card = page.locator(`[data-testid="proposal-card-${PROPOSAL_ID}"]`);
-  await card.waitFor({ timeout: 5000 });
+  await card.waitFor({ timeout: 8000 });
 
-  // Overlay with "FAILED" text should be visible
   const overlay = card.locator('.proposal-status-overlay.execute_failed');
   await expect(overlay).toBeVisible();
   await expect(overlay).toContainText('FAILED');
 });
 
 test('execute success → green toast with confirmation', async ({ page }) => {
-  await page.route('**/api/trades/proposed', (route) => {
-    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(QUEUE_RESPONSE) });
-  });
-  await page.route(`**/api/trades/proposed/${PROPOSAL_ID}/execute`, (route) => {
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ ok: true, status: 'execute', order_result: { parent_order_id: 99001 } }),
-    });
+  await setupRoutes(page, {
+    status: 200,
+    body: { ok: true, status: 'execute', order_result: { parent_order_id: 99001 } },
   });
 
   await gotoAndWait(page);
 
   const execBtn = page.locator(`[data-testid="execute-btn-${PROPOSAL_ID}"]`);
-  await execBtn.waitFor({ timeout: 5000 });
+  await execBtn.waitFor({ timeout: 8000 });
   await execBtn.click();
 
   const toast = page.locator('[data-testid="execute-toast"]');
-  await toast.waitFor({ timeout: 5000 });
+  await toast.waitFor({ timeout: 8000 });
   await expect(toast).toBeVisible();
 
   const toastText = await toast.textContent();
   expect(toastText).toContain('Order submitted');
 
-  // Success toasts auto-dismiss (no permanent dismiss button)
-  const dismissBtn = toast.locator('button[aria-label="Dismiss"]');
-  await expect(dismissBtn).not.toBeVisible();
+  // Success toasts auto-dismiss — no persistent dismiss button
+  await expect(toast.locator('button[aria-label="Dismiss"]')).not.toBeVisible();
 });

--- a/tcode/alpha_control_center/tests/ux_execute_error.spec.ts
+++ b/tcode/alpha_control_center/tests/ux_execute_error.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Phase 18.1 — Execute error surfacing tests
+ *
+ * Verifies:
+ * - API 500 → red persistent toast with error message
+ * - Proposal card shows "FAILED" overlay after execute error
+ * - API success → green toast with confirmation
+ * - Dismiss button clears error toast
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:2112';
+
+const PROPOSAL_ID = 'test-exec-err-001';
+
+const PENDING_PROPOSAL = {
+  id: PROPOSAL_ID,
+  ts_created: new Date(Date.now() - 5000).toISOString(),
+  ts_expires: new Date(Date.now() + 55000).toISOString(),
+  status: 'pending',
+  strategy: 'GAMMA_SCALP',
+  direction: 'BULLISH',
+  legs: [{ strike: 400, type: 'CALL', action: 'BUY', quantity: 1, fill_price: null }],
+  entry_price: 5.0,
+  stop_price: 3.0,
+  target_price: 8.0,
+  kelly_fraction: 0.05,
+  quantity: 1,
+  confidence: 0.72,
+  regime_snapshot: { regime: 'BULLISH_TREND', confidence: 0.8 },
+  signals_contributing: ['GAMMA_SCALP'],
+};
+
+const QUEUE_RESPONSE = {
+  proposals: [PENDING_PROPOSAL],
+  stats: { pending: 1, executed: 0, skipped: 0, expired: 0 },
+  updated_at: new Date().toISOString(),
+};
+
+const FAILED_PROPOSAL = { ...PENDING_PROPOSAL, status: 'execute_failed' };
+
+async function gotoAndWait(page: Page) {
+  await page.goto(BASE, { waitUntil: 'load' });
+  await page.waitForSelector('[data-testid="status-bar"]', { timeout: 15_000 });
+  await page.waitForTimeout(1500);
+}
+
+test('execute API 500 → red toast with error message', async ({ page }) => {
+  // Mock proposals endpoint to return a pending proposal
+  await page.route('**/api/trades/proposed', (route) => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(QUEUE_RESPONSE) });
+  });
+
+  // Mock execute endpoint to return 500 with error body
+  await page.route(`**/api/trades/proposed/${PROPOSAL_ID}/execute`, (route) => {
+    route.fulfill({
+      status: 500,
+      contentType: 'application/json',
+      body: JSON.stringify({ ok: false, error: 'expiry is empty — proposal missing expiration_date' }),
+    });
+  });
+
+  await gotoAndWait(page);
+
+  // Find and click Execute button
+  const execBtn = page.locator(`[data-testid="execute-btn-${PROPOSAL_ID}"]`);
+  await execBtn.waitFor({ timeout: 5000 });
+
+  // In paper mode there's no countdown, click fires immediately
+  await execBtn.click();
+
+  // Red toast should appear
+  const toast = page.locator('[data-testid="execute-toast"]');
+  await toast.waitFor({ timeout: 5000 });
+  await expect(toast).toBeVisible();
+
+  const toastText = await toast.textContent();
+  expect(toastText).toContain('expiry is empty');
+
+  // Error toast has a dismiss button
+  const dismissBtn = toast.locator('button[aria-label="Dismiss"]');
+  await expect(dismissBtn).toBeVisible();
+});
+
+test('dismiss button clears error toast', async ({ page }) => {
+  await page.route('**/api/trades/proposed', (route) => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(QUEUE_RESPONSE) });
+  });
+  await page.route(`**/api/trades/proposed/${PROPOSAL_ID}/execute`, (route) => {
+    route.fulfill({
+      status: 500,
+      contentType: 'application/json',
+      body: JSON.stringify({ ok: false, error: 'strike is 0 — proposal missing recommended_strike' }),
+    });
+  });
+
+  await gotoAndWait(page);
+
+  const execBtn = page.locator(`[data-testid="execute-btn-${PROPOSAL_ID}"]`);
+  await execBtn.waitFor({ timeout: 5000 });
+  await execBtn.click();
+
+  const toast = page.locator('[data-testid="execute-toast"]');
+  await toast.waitFor({ timeout: 5000 });
+
+  const dismissBtn = toast.locator('button[aria-label="Dismiss"]');
+  await dismissBtn.click();
+  await expect(toast).not.toBeVisible();
+});
+
+test('execute_failed status → FAILED overlay on proposal card', async ({ page }) => {
+  // Return proposal already in execute_failed state
+  const failedQueue = {
+    ...QUEUE_RESPONSE,
+    proposals: [FAILED_PROPOSAL],
+  };
+
+  await page.route('**/api/trades/proposed', (route) => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(failedQueue) });
+  });
+
+  await gotoAndWait(page);
+
+  const card = page.locator(`[data-testid="proposal-card-${PROPOSAL_ID}"]`);
+  await card.waitFor({ timeout: 5000 });
+
+  // Overlay with "FAILED" text should be visible
+  const overlay = card.locator('.proposal-status-overlay.execute_failed');
+  await expect(overlay).toBeVisible();
+  await expect(overlay).toContainText('FAILED');
+});
+
+test('execute success → green toast with confirmation', async ({ page }) => {
+  await page.route('**/api/trades/proposed', (route) => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(QUEUE_RESPONSE) });
+  });
+  await page.route(`**/api/trades/proposed/${PROPOSAL_ID}/execute`, (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ok: true, status: 'execute', order_result: { parent_order_id: 99001 } }),
+    });
+  });
+
+  await gotoAndWait(page);
+
+  const execBtn = page.locator(`[data-testid="execute-btn-${PROPOSAL_ID}"]`);
+  await execBtn.waitFor({ timeout: 5000 });
+  await execBtn.click();
+
+  const toast = page.locator('[data-testid="execute-toast"]');
+  await toast.waitFor({ timeout: 5000 });
+  await expect(toast).toBeVisible();
+
+  const toastText = await toast.textContent();
+  expect(toastText).toContain('Order submitted');
+
+  // Success toasts auto-dismiss (no permanent dismiss button)
+  const dismissBtn = toast.locator('button[aria-label="Dismiss"]');
+  await expect(dismissBtn).not.toBeVisible();
+});

--- a/tcode/alpha_engine/publisher.py
+++ b/tcode/alpha_engine/publisher.py
@@ -495,6 +495,18 @@ class SignalPublisher:
                     "fill_price": None,
                 })
 
+            # Guard: required execute fields must be present before emitting
+            _missing = []
+            if not payload.get("expiration_date"):
+                _missing.append("expiration_date")
+            if not payload.get("recommended_strike"):
+                _missing.append("recommended_strike")
+            if not payload.get("option_type"):
+                _missing.append("option_type")
+            if _missing:
+                print(f"[WARN] Dropping proposal — missing required fields: {_missing}")
+                return
+
             proposal = {
                 "id": proposal_id,
                 "ts_created": now_iso,

--- a/tcode/execution_engine/execute_validation_test.go
+++ b/tcode/execution_engine/execute_validation_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func makeProposal(rawSignal map[string]interface{}) *TradeProposal {
+	raw, _ := json.Marshal(rawSignal)
+	return &TradeProposal{
+		ID:          "test-id",
+		EntryPrice:  5.0,
+		TargetPrice: 7.0,
+		StopPrice:   3.0,
+		RawSignal:   json.RawMessage(raw),
+	}
+}
+
+func TestExecuteValidation_EmptyExpiry(t *testing.T) {
+	p := makeProposal(map[string]interface{}{
+		"recommended_strike": 400.0,
+		"option_type":        "CALL",
+		// expiration_date deliberately absent
+	})
+	_, err := executeProposalOrder(p, 1, "paper")
+	if err == nil {
+		t.Fatal("expected error for missing expiry, got nil")
+	}
+	if err.Error() != "expiry is empty — proposal missing expiration_date" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestExecuteValidation_ZeroStrike(t *testing.T) {
+	p := makeProposal(map[string]interface{}{
+		"expiration_date": "2026-04-25",
+		"option_type":     "CALL",
+		// recommended_strike absent → strikeVal stays 0
+	})
+	p.EntryPrice = 0 // also zero so fallback stays 0
+	_, err := executeProposalOrder(p, 1, "paper")
+	if err == nil {
+		t.Fatal("expected error for zero strike, got nil")
+	}
+	if err.Error() != "strike is 0 — proposal missing recommended_strike" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestExecuteValidation_ZeroQty(t *testing.T) {
+	p := makeProposal(map[string]interface{}{
+		"recommended_strike": 400.0,
+		"expiration_date":    "2026-04-25",
+		"option_type":        "CALL",
+	})
+	_, err := executeProposalOrder(p, 0, "paper")
+	if err == nil {
+		t.Fatal("expected error for zero qty, got nil")
+	}
+	if err.Error() != "quantity is 0 — must be positive" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/tcode/execution_engine/phase16_api.go
+++ b/tcode/execution_engine/phase16_api.go
@@ -365,6 +365,14 @@ func (h *ConfigHandler) ServeTradeProposalAction(w http.ResponseWriter, r *http.
 		if execErr != nil {
 			finalStatus = "execute_failed"
 			log.Printf("[PROPOSALS] execute failed for %s: %v", proposalID, execErr)
+			GlobalProposalStore.SetStatus(proposalID, "execute_failed")
+			// Notify operator via Telegram
+			if h.Guard != nil && h.Guard.AlertBot != nil {
+				contract := fmt.Sprintf("TSLA %s — %s", p.Strategy, p.Direction)
+				h.Guard.AlertBot.SendAlert(fmt.Sprintf(
+					"EXECUTE FAILED\n%s\nError: %s", contract, execErr.Error(),
+				))
+			}
 		} else {
 			GlobalProposalStore.SetStatus(proposalID, finalStatus)
 		}
@@ -414,6 +422,18 @@ func executeProposalOrder(p *TradeProposal, qty int, mode string) (map[string]in
 	if v, ok := rawSig["option_type"].(string); ok {
 		optType = v
 	}
+
+	// Validate required fields before invoking ibkr_order.py
+	if strikeVal == 0 {
+		return nil, fmt.Errorf("strike is 0 — proposal missing recommended_strike")
+	}
+	if expiry == "" {
+		return nil, fmt.Errorf("expiry is empty — proposal missing expiration_date")
+	}
+	if qty <= 0 {
+		return nil, fmt.Errorf("quantity is %d — must be positive", qty)
+	}
+
 	limitPrice := fmt.Sprintf("%.4f", p.EntryPrice)
 	tp := fmt.Sprintf("%.4f", p.TargetPrice)
 	sl := fmt.Sprintf("%.4f", p.StopPrice)
@@ -434,7 +454,10 @@ func executeProposalOrder(p *TradeProposal, qty int, mode string) (map[string]in
 	cmd.Dir = "/home/builder/src/gpfiles/tcode"
 	cmd.Env = os.Environ()
 
+	log.Printf("[PROPOSALS] executing: python %s", strings.Join(args, " "))
+
 	out, err := cmd.Output()
+	log.Printf("[PROPOSALS] ibkr_order output: %s", strings.TrimSpace(string(out)))
 	if err != nil {
 		return nil, fmt.Errorf("ibkr_order.py failed: %w", err)
 	}


### PR DESCRIPTION
## Fixes
- Execute errors now surface as red toast + FAILED badge on proposal card (was silent)
- Validates strike/expiry/qty before calling ibkr_order.py — rejects with clear error if missing
- Full command + output logging for execute attempts
- Publisher ensures proposals include expiration_date
- Market state label: 4 states (MARKET OPEN / PRE-MARKET / AFTER HOURS / CLOSED) with correct theme + countdown

## Tests
- ux_execute_error.spec.ts: 4 Playwright specs (500 error → red toast, dismiss, FAILED badge, success → green toast)