### PR TITLE
Phase 21 — pause-silent guarantee + runtime watchdog + site-down hotfix

### DIFF
--- a/tcode/alpha_control_center/src/App.tsx
+++ b/tcode/alpha_control_center/src/App.tsx
@@ -52,6 +52,7 @@ import IntegrityStatus from './components/IntegrityStatus';
 import HelpPanel from './components/HelpPanel';
 import SystemHealthPanel, { type HealthSummary } from './components/SystemHealthPanel';
 import PauseOverlay, { PauseCountdown, type PauseStatus } from './components/PauseOverlay';
+import PauseWatchdogBadge from './components/PauseWatchdogBadge';
 import { Shield, Menu, Home, Share2, Map, HelpCircle } from 'lucide-react';
 import Dashboard from './pages/Dashboard';
 import Architecture from './pages/Architecture';
@@ -435,6 +436,8 @@ function App() {
         <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
             {/* Pause countdown — kept in nav for visibility */}
             <PauseCountdown status={pauseStatus} onPause={handlePause} />
+            {/* Phase 21: pause leak watchdog badge */}
+            <PauseWatchdogBadge />
             {/* Integrity Status — three traffic lights */}
             <IntegrityStatus onStatusChange={handleIntegrityChange} />
             {/* Market state badge */}

--- a/tcode/alpha_control_center/src/components/MergedPositionsTable.tsx
+++ b/tcode/alpha_control_center/src/components/MergedPositionsTable.tsx
@@ -163,7 +163,11 @@ const MergedPositionsTable: React.FC<MergedPositionsTableProps> = ({ onClose }) 
   const handleCancelOrder = async (orderId: number) => {
     setCancelling(prev => new Set([...prev, orderId]));
     try {
-      await fetch(`/api/orders/${orderId}/cancel`, { method: 'POST' });
+      await fetch('/api/orders/cancel', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ order_id: orderId }),
+      });
       await fetchOrders();
     } finally {
       setCancelling(prev => { const n = new Set(prev); n.delete(orderId); return n; });

--- a/tcode/alpha_control_center/src/components/PauseWatchdogBadge.tsx
+++ b/tcode/alpha_control_center/src/components/PauseWatchdogBadge.tsx
@@ -1,0 +1,108 @@
+/**
+ * PauseWatchdogBadge — Phase 21
+ *
+ * Shows the pause leak watchdog status as a small badge in the UI.
+ * Polls /api/pause/watchdog-status every 10 seconds.
+ *
+ * States:
+ *   ok=true  → green "Silent" badge (no leaks detected while paused)
+ *   ok=false → red "LEAK DETECTED" badge with leak count
+ *   daemon not running → grey "Watchdog off" badge
+ */
+import { useState, useEffect } from 'react';
+
+interface WatchdogStatus {
+  ok: boolean;
+  paused: boolean;
+  leak_count: number;
+  leaks: Array<{ ts: number; fn: string; module: string }>;
+  last_checked: number;
+}
+
+const POLL_MS = 10_000;
+
+export default function PauseWatchdogBadge() {
+  const [status, setStatus] = useState<WatchdogStatus | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const r = await fetch('/api/pause/watchdog-status');
+        if (r.ok) {
+          setStatus(await r.json());
+          setError(false);
+        } else {
+          setError(true);
+        }
+      } catch {
+        setError(true);
+      }
+      if (!cancelled) timer = setTimeout(poll, POLL_MS);
+    };
+
+    poll();
+    return () => { cancelled = true; clearTimeout(timer); };
+  }, []);
+
+  const baseStyle: React.CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '4px',
+    padding: '2px 8px',
+    borderRadius: '10px',
+    fontSize: '11px',
+    fontWeight: 700,
+    fontFamily: 'monospace',
+    cursor: 'default',
+    userSelect: 'none',
+  };
+
+  if (error || status === null) {
+    return (
+      <span
+        style={{ ...baseStyle, background: '#30363d', color: '#8b949e', border: '1px solid #30363d' }}
+        title="Pause watchdog daemon not running — start pause_leak_detector.py"
+      >
+        ◉ Watchdog off
+      </span>
+    );
+  }
+
+  if (!status.paused) {
+    // System is unpaused — watchdog is monitoring but not actively checking for leaks
+    return (
+      <span
+        style={{ ...baseStyle, background: '#0d1117', color: '#3fb950', border: '1px solid #238636' }}
+        title="System is active (unpaused). Watchdog monitors during pause windows."
+      >
+        ◉ Active
+      </span>
+    );
+  }
+
+  if (status.ok) {
+    return (
+      <span
+        style={{ ...baseStyle, background: '#0f2c1a', color: '#3fb950', border: '1px solid #238636' }}
+        title="Paused & silent — no network leaks detected"
+      >
+        ✓ Silent
+      </span>
+    );
+  }
+
+  // Leak detected
+  const leakFns = status.leaks.slice(-3).map(l => `${l.module}.${l.fn}`).join(', ');
+  return (
+    <span
+      style={{ ...baseStyle, background: '#6e1919', color: '#f85149', border: '2px solid #f85149', animation: 'pulse 1s infinite' }}
+      title={`LEAK: ${status.leak_count} blocked call(s) slipped through while paused.\nFunctions: ${leakFns}`}
+    >
+      ⚠ LEAK ({status.leak_count})
+    </span>
+  );
+}

--- a/tcode/alpha_engine/ingestion/catalyst_tracker.py
+++ b/tcode/alpha_engine/ingestion/catalyst_tracker.py
@@ -7,6 +7,12 @@ import time
 import logging
 from typing import Optional
 
+try:
+    from pause_guard import pause_guard as _pause_guard
+except ImportError:  # pragma: no cover — fallback when imported outside normal path
+    def _pause_guard(fn):  # type: ignore[misc]
+        return fn
+
 logger = logging.getLogger("CatalystTracker")
 
 # Module-level cache
@@ -121,6 +127,7 @@ def _fetch_analyst_consensus() -> dict:
         return {"analyst_consensus": "N/A", "recent_changes": [], "strong_buy_count": 0, "sell_count": 0}
 
 
+@_pause_guard
 def get_catalyst_intel() -> dict:
     """Return combined Musk sentiment + analyst consensus. Cached with separate TTLs."""
     global _catalyst_cache, _catalyst_cache_ts, _analyst_cache, _analyst_cache_ts

--- a/tcode/alpha_engine/ingestion/congress_trades.py
+++ b/tcode/alpha_engine/ingestion/congress_trades.py
@@ -49,6 +49,12 @@ try:
 except Exception:
     def _hb(component, status="ok", detail=None, **_kw): pass  # type: ignore
 
+try:
+    from pause_guard import pause_guard as _pause_guard
+except ImportError:  # pragma: no cover
+    def _pause_guard(fn):  # type: ignore[misc]
+        return fn
+
 _CACHE: Optional[dict] = None
 _CACHE_TS: float = 0.0
 _CACHE_TTL = 3600  # 1 hour — disclosures trickle in; no need to hammer gov servers
@@ -191,6 +197,7 @@ def _is_within_48h(date_str: str) -> bool:
     return False
 
 
+@_pause_guard
 def _fetch_senate_ptrs() -> list[dict]:
     """
     Query Senate Electronic Financial Disclosures (eFTS) for recent TSLA PTR filings.
@@ -299,6 +306,7 @@ def _fetch_senate_ptrs() -> list[dict]:
     return trades
 
 
+@_pause_guard
 def _fetch_house_ptrs() -> list[dict]:
     """
     Fetch House Periodic Transaction Reports.

--- a/tcode/alpha_engine/ingestion/ev_sector.py
+++ b/tcode/alpha_engine/ingestion/ev_sector.py
@@ -7,6 +7,12 @@ import time
 import logging
 from typing import Optional
 
+try:
+    from pause_guard import pause_guard as _pause_guard
+except ImportError:  # pragma: no cover
+    def _pause_guard(fn):  # type: ignore[misc]
+        return fn
+
 logger = logging.getLogger("EVSector")
 
 _ev_cache: Optional[dict] = None
@@ -87,6 +93,7 @@ def _fetch_ev_sector() -> dict:
         return {"competitors": {}, "sector_etf": {}, "sector_direction": "NEUTRAL", "tsla_relative_strength": 0.0}
 
 
+@_pause_guard
 def get_ev_sector_intel() -> dict:
     """Return EV sector intel. Cached 5 minutes."""
     global _ev_cache, _ev_cache_ts

--- a/tcode/alpha_engine/ingestion/institutional.py
+++ b/tcode/alpha_engine/ingestion/institutional.py
@@ -7,6 +7,12 @@ import time
 import logging
 from typing import Optional
 
+try:
+    from pause_guard import pause_guard as _pause_guard
+except ImportError:  # pragma: no cover
+    def _pause_guard(fn):  # type: ignore[misc]
+        return fn
+
 logger = logging.getLogger("Institutional")
 
 _inst_cache: Optional[dict] = None
@@ -122,6 +128,7 @@ def _fetch_insider_activity() -> dict:
         return {"recent_transactions": [], "net_insider_sentiment": "NEUTRAL", "buy_count": 0, "sell_count": 0}
 
 
+@_pause_guard
 def get_institutional_intel() -> dict:
     """Return combined institutional holders + insider activity. Cached 1 hour."""
     global _inst_cache, _inst_cache_ts

--- a/tcode/alpha_engine/ingestion/intel.py
+++ b/tcode/alpha_engine/ingestion/intel.py
@@ -18,6 +18,12 @@ try:
 except Exception:
     def _hb(component, status="ok", detail=None, **_kw): pass  # type: ignore
 
+try:
+    from pause_guard import pause_guard as _pause_guard
+except ImportError:  # pragma: no cover
+    def _pause_guard(fn):  # type: ignore[misc]
+        return fn
+
 # Module-level cache: {"data": ..., "ts": float}
 _cache: dict[str, Any] = {}
 _CACHE_TTL = 300  # 5 minutes
@@ -187,6 +193,7 @@ def _fetch_options_flow() -> dict:
         }
 
 
+@_pause_guard
 def get_intel() -> dict:
     """
     Fetch all intel sources. Results are cached for 5 minutes.

--- a/tcode/alpha_engine/ingestion/macro_regime.py
+++ b/tcode/alpha_engine/ingestion/macro_regime.py
@@ -24,6 +24,12 @@ try:
 except Exception:
     def _hb(component, status="ok", detail=None, **_kw): pass  # type: ignore
 
+try:
+    from pause_guard import pause_guard as _pause_guard
+except ImportError:  # pragma: no cover
+    def _pause_guard(fn):  # type: ignore[misc]
+        return fn
+
 _macro_cache: Optional[dict] = None
 _macro_cache_ts: float = 0.0
 _MACRO_TTL = 3600  # 1 hour for macro data
@@ -266,6 +272,7 @@ def _fetch_vix_term_structure() -> dict:
         return {"vix_spot": 0.0, "vix_9d": 0.0, "term_structure": "CONTANGO"}
 
 
+@_pause_guard
 def get_macro_regime() -> dict:
     """Return macro regime classification. Macro data cached 1hr, VIX 5min."""
     global _macro_cache, _macro_cache_ts, _vix_cache, _vix_cache_ts

--- a/tcode/alpha_engine/ingestion/premarket.py
+++ b/tcode/alpha_engine/ingestion/premarket.py
@@ -26,6 +26,12 @@ try:
 except Exception:
     def _hb(component, status="ok", detail=None, **_kw): pass  # type: ignore
 
+try:
+    from pause_guard import pause_guard as _pause_guard
+except ImportError:  # pragma: no cover
+    def _pause_guard(fn):  # type: ignore[misc]
+        return fn
+
 _premarket_cache: Optional[dict] = None
 _premarket_cache_ts: float = 0.0
 _PREMARKET_TTL = 60  # 1 minute — needs freshness during pre-market window
@@ -80,6 +86,7 @@ def _bias_label(score: float) -> str:
     return "MIXED"
 
 
+@_pause_guard
 def _fetch_premarket() -> dict:
     """
     Fetch US futures, European/Asian indices, FX, and TSLA pre-market data.

--- a/tcode/alpha_engine/ingestion/tradier_chain.py
+++ b/tcode/alpha_engine/ingestion/tradier_chain.py
@@ -22,6 +22,12 @@ import logging
 
 import requests
 
+try:
+    from pause_guard import pause_guard as _pause_guard
+except ImportError:  # pragma: no cover
+    def _pause_guard(fn):  # type: ignore[misc]
+        return fn
+
 logger = logging.getLogger("TradierChain")
 
 TRADIER_BASE_URL = os.getenv("TRADIER_BASE_URL", "https://api.tradier.com/v1")
@@ -86,6 +92,7 @@ def _request(method: str, path: str, params: dict | None = None) -> dict:
     raise RuntimeError(f"Tradier request failed after {_RETRY_ATTEMPTS} attempts: {last_exc}") from last_exc
 
 
+@_pause_guard
 def get_expirations(symbol: str = "TSLA") -> list[str]:
     """
     GET /markets/options/expirations?symbol=TSLA
@@ -112,6 +119,7 @@ def get_expirations(symbol: str = "TSLA") -> list[str]:
     return list(dates)
 
 
+@_pause_guard
 def get_chain(symbol: str, expiration: str) -> list[dict]:
     """
     GET /markets/options/chains?symbol=TSLA&expiration=2026-04-17&greeks=true
@@ -154,6 +162,7 @@ def get_chain(symbol: str, expiration: str) -> list[dict]:
     return list(option_list)
 
 
+@_pause_guard
 def get_quotes(symbol: str) -> dict:
     """
     GET /markets/quotes?symbols=TSLA

--- a/tcode/alpha_engine/pause_guard.py
+++ b/tcode/alpha_engine/pause_guard.py
@@ -1,0 +1,143 @@
+"""
+pause_guard.py — Phase 21: bulletproof pause-means-silent guarantee.
+
+Provides:
+  is_paused()              — reads pause state with 500ms TTL cache
+  @pause_guard             — decorator for sync ingestion entry points
+  @pause_guard_async       — decorator for async ingestion entry points
+  _record_blocked_call()   — appends a JSONL entry to PAUSE_BLOCKS_LOG
+
+When paused, decorated functions return None immediately (no network I/O).
+Every blocked call is logged to stderr and recorded in PAUSE_BLOCKS_LOG
+so the watchdog daemon can detect leaks.
+
+Pause state is read from PAUSE_STATE_FILE (same file the Go API writes).
+Default: /tmp/tsla_alpha_pause_state.json (overridable via env var).
+"""
+from __future__ import annotations
+
+import functools
+import json
+import logging
+import os
+import time
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+
+PAUSE_STATE_FILE: str = os.getenv(
+    "PUBLISHER_PAUSE_STATE_FILE",
+    "/tmp/tsla_alpha_pause_state.json",
+)
+PAUSE_BLOCKS_LOG: str = os.getenv(
+    "PAUSE_BLOCKS_LOG",
+    "/tmp/pause_blocks.jsonl",
+)
+
+# TTL for the in-process pause-state cache (seconds).
+_CACHE_TTL_SEC: float = 0.5
+
+# ── Cache ──────────────────────────────────────────────────────────────────────
+
+_cache_value: bool = True          # safe default: treat as paused
+_cache_expires_at: float = 0.0     # epoch seconds
+
+
+def _read_raw() -> bool:
+    """Read pause state from disk. Returns True (paused) on any error."""
+    import datetime as _dt
+    try:
+        with open(PAUSE_STATE_FILE) as fh:
+            state = json.load(fh)
+        if state.get("paused", True):
+            return True
+        # Check expiry
+        until_str = state.get("unpause_until")
+        if until_str:
+            until = _dt.datetime.fromisoformat(until_str.replace("Z", "+00:00"))
+            if _dt.datetime.now(_dt.timezone.utc) > until:
+                return True   # window expired → paused
+        return False
+    except Exception:
+        return True   # any error → fail-safe: paused
+
+
+def is_paused() -> bool:
+    """Return True if the system is currently paused.
+
+    Result is cached for _CACHE_TTL_SEC (500ms) to avoid disk thrash when
+    many ingestion functions check in quick succession.
+    """
+    global _cache_value, _cache_expires_at
+    now = time.monotonic()
+    if now < _cache_expires_at:
+        return _cache_value
+    _cache_value = _read_raw()
+    _cache_expires_at = now + _CACHE_TTL_SEC
+    return _cache_value
+
+
+# ── Block recorder ─────────────────────────────────────────────────────────────
+
+def _record_blocked_call(fn_name: str, module: str) -> None:
+    """Append a JSONL record to PAUSE_BLOCKS_LOG and emit a log warning."""
+    record = {
+        "ts": time.time(),
+        "fn": fn_name,
+        "module": module,
+    }
+    logger.warning("[PAUSE-GUARD] blocked %s.%s (system is paused)", module, fn_name)
+    try:
+        with open(PAUSE_BLOCKS_LOG, "a") as fh:
+            fh.write(json.dumps(record) + "\n")
+    except OSError as exc:
+        logger.debug("[PAUSE-GUARD] could not write to %s: %s", PAUSE_BLOCKS_LOG, exc)
+
+
+# ── Decorators ─────────────────────────────────────────────────────────────────
+
+def pause_guard(fn: Callable) -> Callable:
+    """Decorator for *synchronous* ingestion entry points.
+
+    When the system is paused, the function body is skipped and None is returned.
+    Use on any function that makes external HTTP/socket calls.
+
+    Usage::
+        @pause_guard
+        def fetch_senate_trades() -> list[dict]:
+            ...
+    """
+    mod = fn.__module__ or "unknown"
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if is_paused():
+            _record_blocked_call(fn.__name__, mod)
+            return None
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
+def pause_guard_async(fn: Callable) -> Callable:
+    """Decorator for *async* ingestion entry points.
+
+    Same semantics as @pause_guard but for coroutine functions.
+
+    Usage::
+        @pause_guard_async
+        async def fetch_realtime_data() -> dict:
+            ...
+    """
+    mod = fn.__module__ or "unknown"
+
+    @functools.wraps(fn)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if is_paused():
+            _record_blocked_call(fn.__name__, mod)
+            return None
+        return await fn(*args, **kwargs)
+
+    return wrapper

--- a/tcode/alpha_engine/pause_leak_detector.py
+++ b/tcode/alpha_engine/pause_leak_detector.py
@@ -1,0 +1,218 @@
+"""
+pause_leak_detector.py — Phase 21: pause-leak watchdog daemon.
+
+Monitors /tmp/pause_blocks.jsonl for blocked-call records written by
+pause_guard.py. When the system is paused, this file should be empty
+(or have only very old entries). If NEW entries appear while the system
+claims to be paused, it indicates a leak — an ingestion function is
+making external calls despite the guard.
+
+AlertThrottle: first alert fires immediately; subsequent alerts for the
+same function within window_sec (600s = 10 min) are batched into a
+single digest, preventing alert fatigue.
+
+Writes /tmp/pause_watchdog_status.json every poll cycle so the frontend
+badge and Go API endpoint can read it without spawning a subprocess.
+
+Usage (run as a background daemon):
+    python3 pause_leak_detector.py
+
+Environment:
+    PAUSE_BLOCKS_LOG      path to pause_blocks.jsonl (default /tmp/pause_blocks.jsonl)
+    WATCHDOG_STATUS_FILE  path for status JSON (default /tmp/pause_watchdog_status.json)
+    WATCHDOG_POLL_SEC     poll interval in seconds (default 30)
+    TELEGRAM_TOKEN        bot token for Telegram alerts (optional)
+    TELEGRAM_CHAT_ID      chat ID for Telegram alerts (optional)
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [WATCHDOG] %(levelname)s %(message)s",
+)
+logger = logging.getLogger("PauseWatchdog")
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+
+PAUSE_BLOCKS_LOG: str = os.getenv("PAUSE_BLOCKS_LOG", "/tmp/pause_blocks.jsonl")
+WATCHDOG_STATUS_FILE: str = os.getenv("WATCHDOG_STATUS_FILE", "/tmp/pause_watchdog_status.json")
+WATCHDOG_POLL_SEC: float = float(os.getenv("WATCHDOG_POLL_SEC", "30"))
+
+
+# ── Alert throttling ───────────────────────────────────────────────────────────
+
+class AlertThrottle:
+    """Throttle repeated alerts for the same key within a rolling window.
+
+    First alert per key fires immediately. Subsequent alerts within window_sec
+    are batched; a digest is sent once when the window closes.
+    """
+
+    def __init__(self, window_sec: float = 600.0) -> None:
+        self.window_sec = window_sec
+        self._first_seen: dict[str, float] = {}   # key → first alert epoch
+        self._batch: dict[str, list[dict]] = defaultdict(list)  # key → buffered records
+        self._last_digest_sent: dict[str, float] = {}
+
+    def record(self, key: str, record: dict) -> bool:
+        """Record an event. Returns True if an immediate alert should fire.
+
+        After the first alert, events are batched until drain() is called.
+        """
+        now = time.time()
+        if key not in self._first_seen:
+            self._first_seen[key] = now
+            self._last_digest_sent[key] = now
+            return True  # fire immediately
+        self._batch[key].append(record)
+        return False
+
+    def drain(self) -> dict[str, list[dict]]:
+        """Return batched records for keys whose window has expired. Clears batch."""
+        now = time.time()
+        digests: dict[str, list[dict]] = {}
+        for key, records in list(self._batch.items()):
+            if records and now - self._last_digest_sent.get(key, 0) >= self.window_sec:
+                digests[key] = records
+                self._batch[key] = []
+                self._last_digest_sent[key] = now
+        return digests
+
+
+# ── Telegram helper ────────────────────────────────────────────────────────────
+
+def _send_telegram(msg: str) -> None:
+    """Send a Telegram message if TELEGRAM_TOKEN and TELEGRAM_CHAT_ID are set."""
+    token = os.getenv("TELEGRAM_TOKEN", "")
+    chat_id = os.getenv("TELEGRAM_CHAT_ID", "")
+    if not token or not chat_id:
+        return
+    try:
+        import urllib.request
+        payload = json.dumps({"chat_id": chat_id, "text": msg}).encode()
+        req = urllib.request.Request(
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=10):
+            pass
+    except Exception as exc:
+        logger.warning("Telegram alert failed: %s", exc)
+
+
+# ── Watchdog state ─────────────────────────────────────────────────────────────
+
+def _write_status(leaks: list[dict], last_checked: float, paused: bool) -> None:
+    """Write /tmp/pause_watchdog_status.json for the Go API + frontend badge."""
+    status = {
+        "ok": len(leaks) == 0,
+        "paused": paused,
+        "leak_count": len(leaks),
+        "leaks": leaks[-10:],  # last 10 leak records for display
+        "last_checked": last_checked,
+    }
+    try:
+        tmp = WATCHDOG_STATUS_FILE + ".tmp"
+        with open(tmp, "w") as fh:
+            json.dump(status, fh)
+        os.replace(tmp, WATCHDOG_STATUS_FILE)
+    except OSError as exc:
+        logger.warning("Failed to write watchdog status: %s", exc)
+
+
+# ── Import pause check ─────────────────────────────────────────────────────────
+
+_ALPHA_ENGINE = os.path.dirname(os.path.abspath(__file__))
+if _ALPHA_ENGINE not in sys.path:
+    sys.path.insert(0, _ALPHA_ENGINE)
+
+
+def _is_currently_paused() -> bool:
+    try:
+        from pause_guard import _read_raw
+        return _read_raw()
+    except Exception:
+        return False
+
+
+# ── Main loop ──────────────────────────────────────────────────────────────────
+
+def run_watchdog() -> None:
+    """Blocking watchdog loop. Run as a daemon process."""
+    logger.info("Pause leak watchdog started (poll=%.0fs, log=%s)", WATCHDOG_POLL_SEC, PAUSE_BLOCKS_LOG)
+    throttle = AlertThrottle(window_sec=600.0)
+    _last_offset: int = 0          # byte offset to track new JSONL lines
+    _active_leaks: list[dict] = []
+
+    while True:
+        paused = _is_currently_paused()
+        new_leaks: list[dict] = []
+
+        if paused:
+            # Read any new entries from PAUSE_BLOCKS_LOG
+            try:
+                path = Path(PAUSE_BLOCKS_LOG)
+                if path.exists():
+                    with open(path, "r") as fh:
+                        fh.seek(_last_offset)
+                        for line in fh:
+                            line = line.strip()
+                            if not line:
+                                continue
+                            try:
+                                record = json.loads(line)
+                            except json.JSONDecodeError:
+                                continue
+                            # Only flag records written AFTER the last poll
+                            if record.get("ts", 0) > time.time() - WATCHDOG_POLL_SEC * 2:
+                                new_leaks.append(record)
+                        _last_offset = fh.tell()
+            except OSError:
+                pass
+
+            for record in new_leaks:
+                fn_key = f"{record.get('module', '?')}.{record.get('fn', '?')}"
+                _active_leaks.append(record)
+                if throttle.record(fn_key, record):
+                    msg = (
+                        f"🚨 PAUSE LEAK: {fn_key} made an external call "
+                        f"while system is PAUSED at {time.strftime('%H:%M:%S UTC', time.gmtime(record.get('ts', time.time())))}"
+                    )
+                    logger.error(msg)
+                    _send_telegram(msg)
+
+            # Send digest for throttled alerts
+            for key, records in throttle.drain().items():
+                msg = (
+                    f"⚠️ PAUSE LEAK DIGEST: {key} was called {len(records)} more time(s) "
+                    f"while paused in the last 10 minutes."
+                )
+                logger.warning(msg)
+                _send_telegram(msg)
+
+        else:
+            # System unpaused — clear active leaks list
+            if _active_leaks:
+                logger.info("System unpaused; clearing %d active leak records", len(_active_leaks))
+                _active_leaks.clear()
+
+        _write_status(
+            leaks=_active_leaks,
+            last_checked=time.time(),
+            paused=paused,
+        )
+
+        time.sleep(WATCHDOG_POLL_SEC)
+
+
+if __name__ == "__main__":
+    run_watchdog()

--- a/tcode/alpha_engine/socket_guard.py
+++ b/tcode/alpha_engine/socket_guard.py
@@ -1,0 +1,100 @@
+"""
+socket_guard.py — Phase 21: socket-level network blocking during pause.
+
+When installed, monkeypatches socket.create_connection so that any attempt
+to open an outbound TCP connection is blocked unless the destination is on
+the whitelist (NATS localhost:4222 or IBKR gateway localhost:4002).
+
+Usage (call once at process startup)::
+    from socket_guard import install_socket_guard
+    install_socket_guard()
+
+After installation, all subsequent calls to socket.create_connection that
+target non-whitelisted hosts will raise PausedNetworkError when is_paused()
+returns True.  Whitelisted connections (NATS, IBKR gateway) are always
+allowed regardless of pause state, so the heartbeat loop and live-order
+management continue to function.
+
+Whitelist entries are (host_lower, port) tuples.  Both "localhost" and
+"127.0.0.1" forms are accepted.
+"""
+from __future__ import annotations
+
+import logging
+import socket as _socket_module
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ── Whitelist: connections always allowed during pause ─────────────────────────
+# localhost:4222 — NATS server (heartbeat, signal emission)
+# localhost:4002 — IBKR paper gateway (order management / position queries)
+_ALWAYS_ALLOWED: frozenset[tuple[str, int]] = frozenset({
+    ("localhost", 4222),
+    ("127.0.0.1", 4222),
+    ("localhost", 4002),
+    ("127.0.0.1", 4002),
+})
+
+_original_create_connection = _socket_module.create_connection
+_guard_installed: bool = False
+
+
+class PausedNetworkError(ConnectionRefusedError):
+    """Raised when a non-whitelisted connection is attempted while paused."""
+
+
+def _is_whitelisted(address: tuple[str, int]) -> bool:
+    host, port = address[0].lower(), address[1]
+    return (host, port) in _ALWAYS_ALLOWED
+
+
+def _guarded_create_connection(
+    address: tuple[str, int],
+    timeout: Any = _socket_module._GLOBAL_DEFAULT_TIMEOUT,
+    source_address: Any = None,
+    *,
+    all_errors: bool = False,
+) -> _socket_module.socket:
+    """Replacement for socket.create_connection that blocks non-whitelisted connections during pause."""
+    from pause_guard import is_paused
+
+    if is_paused() and not _is_whitelisted(address):
+        host, port = address
+        logger.warning(
+            "[SOCKET-GUARD] blocked outbound TCP %s:%s (system is paused)",
+            host, port,
+        )
+        raise PausedNetworkError(
+            f"[socket_guard] connection to {host}:{port} blocked — system is paused. "
+            f"Whitelisted: NATS localhost:4222, IBKR localhost:4002."
+        )
+
+    # Pass through to the original implementation.
+    # Handle the all_errors kwarg which was added in Python 3.11.
+    try:
+        return _original_create_connection(
+            address, timeout, source_address, all_errors=all_errors
+        )
+    except TypeError:
+        return _original_create_connection(address, timeout, source_address)
+
+
+def install_socket_guard() -> None:
+    """Install the socket-level network guard (idempotent)."""
+    global _guard_installed
+    if _guard_installed:
+        return
+    _socket_module.create_connection = _guarded_create_connection  # type: ignore[assignment]
+    _guard_installed = True
+    logger.info(
+        "[SOCKET-GUARD] installed — non-whitelisted connections blocked when paused "
+        "(whitelist: NATS localhost:4222, IBKR localhost:4002)"
+    )
+
+
+def uninstall_socket_guard() -> None:
+    """Remove the socket guard and restore the original function (for tests)."""
+    global _guard_installed
+    _socket_module.create_connection = _original_create_connection  # type: ignore[assignment]
+    _guard_installed = False

--- a/tcode/alpha_engine/tests/test_pause_guard_coverage.py
+++ b/tcode/alpha_engine/tests/test_pause_guard_coverage.py
@@ -1,0 +1,127 @@
+"""
+test_pause_guard_coverage.py — Phase 21: AST-based contract test.
+
+Asserts that every ingestion module that makes external HTTP/socket calls
+has at least one @_pause_guard (or @pause_guard) decorator applied to a
+public entry-point function.
+
+Uses Python's ast module to parse source without executing it, so no
+network calls or environment setup required.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import textwrap
+from pathlib import Path
+
+import pytest
+
+INGESTION_DIR = Path(__file__).parent.parent / "ingestion"
+
+# Map: filename → expected decorated function names (at least one must be decorated).
+# A module passes if ANY function in its required set is decorated.
+REQUIRED_GUARDS: dict[str, list[str]] = {
+    "catalyst_tracker.py": ["get_catalyst_intel"],
+    "ev_sector.py":        ["get_ev_sector_intel"],
+    "institutional.py":    ["get_institutional_intel"],
+    "macro_regime.py":     ["get_macro_regime"],
+    "intel.py":            ["get_intel"],
+    "tradier_chain.py":    ["get_expirations", "get_chain", "get_quotes"],
+    "premarket.py":        ["_fetch_premarket"],
+    "congress_trades.py":  ["_fetch_senate_ptrs", "_fetch_house_ptrs"],
+}
+
+
+def _collect_decorated_functions(source: str, decorator_names: set[str]) -> set[str]:
+    """Return names of functions decorated with any of decorator_names."""
+    tree = ast.parse(source)
+    decorated: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for dec in node.decorator_list:
+            # @_pause_guard  or  @pause_guard
+            if isinstance(dec, ast.Name) and dec.id in decorator_names:
+                decorated.add(node.name)
+            # @module._pause_guard
+            elif isinstance(dec, ast.Attribute) and dec.attr in decorator_names:
+                decorated.add(node.name)
+    return decorated
+
+
+GUARD_NAMES = {"_pause_guard", "pause_guard"}
+
+
+@pytest.mark.parametrize("filename,required_fns", REQUIRED_GUARDS.items())
+def test_module_has_pause_guard(filename: str, required_fns: list[str]) -> None:
+    """At least one function in required_fns must be decorated with @_pause_guard."""
+    path = INGESTION_DIR / filename
+    assert path.exists(), f"Expected ingestion module {filename} not found at {path}"
+
+    source = path.read_text(encoding="utf-8")
+    decorated = _collect_decorated_functions(source, GUARD_NAMES)
+
+    decorated_required = [fn for fn in required_fns if fn in decorated]
+    assert decorated_required, (
+        f"{filename}: none of {required_fns} is decorated with @_pause_guard or @pause_guard.\n"
+        f"Functions decorated in this file: {sorted(decorated) or '(none)'}\n"
+        f"Add @_pause_guard to at least one of {required_fns} to satisfy the Phase 21 "
+        f"pause-silence contract."
+    )
+
+
+def test_pause_guard_module_exists() -> None:
+    """pause_guard.py must exist at alpha_engine root."""
+    pg = Path(__file__).parent.parent / "pause_guard.py"
+    assert pg.exists(), (
+        "pause_guard.py not found at alpha_engine/. "
+        "Create it with is_paused(), @pause_guard, and @pause_guard_async."
+    )
+
+
+def test_pause_guard_has_required_api() -> None:
+    """pause_guard.py must export is_paused, pause_guard, pause_guard_async."""
+    pg = Path(__file__).parent.parent / "pause_guard.py"
+    source = pg.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    top_level_names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            top_level_names.add(node.name)
+
+    required = {"is_paused", "pause_guard", "pause_guard_async", "_record_blocked_call"}
+    missing = required - top_level_names
+    assert not missing, (
+        f"pause_guard.py is missing required symbols: {missing}. "
+        f"Found: {sorted(top_level_names)}"
+    )
+
+
+def test_socket_guard_module_exists() -> None:
+    """socket_guard.py must exist at alpha_engine root."""
+    sg = Path(__file__).parent.parent / "socket_guard.py"
+    assert sg.exists(), (
+        "socket_guard.py not found at alpha_engine/. "
+        "Create it with install_socket_guard() and a localhost whitelist."
+    )
+
+
+def test_socket_guard_has_required_api() -> None:
+    """socket_guard.py must export install_socket_guard and uninstall_socket_guard."""
+    sg = Path(__file__).parent.parent / "socket_guard.py"
+    source = sg.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    top_level_names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            top_level_names.add(node.name)
+
+    required = {"install_socket_guard", "uninstall_socket_guard"}
+    missing = required - top_level_names
+    assert not missing, (
+        f"socket_guard.py is missing required symbols: {missing}. "
+        f"Found: {sorted(top_level_names)}"
+    )

--- a/tcode/alpha_engine/tests/test_pause_silence.py
+++ b/tcode/alpha_engine/tests/test_pause_silence.py
@@ -1,0 +1,164 @@
+"""
+test_pause_silence.py — Phase 21: zero network calls when paused.
+
+Verifies that decorated ingestion entry points make ZERO external calls
+(requests.get, yfinance, etc.) when the system is paused.
+
+Strategy: force is_paused() to return True via monkeypatching, then assert
+that each entry-point function returns None without touching the network.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import importlib
+
+import pytest
+
+# Ensure alpha_engine root is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "ingestion")))
+
+
+def _force_paused(monkeypatch, tmp_path):
+    """Write a paused state file and point PUBLISHER_PAUSE_STATE_FILE at it."""
+    pf = tmp_path / "pause.json"
+    pf.write_text(json.dumps({"paused": True, "unpause_until": None}))
+    monkeypatch.setenv("PUBLISHER_PAUSE_STATE_FILE", str(pf))
+    # Reset the pause_guard cache so the new file is read.
+    import pause_guard as pg
+    pg._cache_expires_at = 0.0  # invalidate TTL cache
+    return str(pf)
+
+
+class TestCatalystTrackerSilence:
+    def test_get_catalyst_intel_returns_none_when_paused(self, monkeypatch, tmp_path):
+        _force_paused(monkeypatch, tmp_path)
+        import pause_guard as pg
+        pg._cache_expires_at = 0.0
+
+        # Stub requests so any accidental call is detected
+        request_calls = []
+        import unittest.mock as mock
+        with mock.patch("requests.get", side_effect=lambda *a, **kw: request_calls.append(a) or mock.MagicMock(json=lambda: {})):
+            import ingestion.catalyst_tracker as ct
+            result = ct.get_catalyst_intel()
+
+        assert result is None, f"Expected None when paused, got {result!r}"
+        assert request_calls == [], f"requests.get was called {len(request_calls)} time(s) while paused"
+
+
+class TestEVSectorSilence:
+    def test_get_ev_sector_intel_returns_none_when_paused(self, monkeypatch, tmp_path):
+        _force_paused(monkeypatch, tmp_path)
+        import pause_guard as pg
+        pg._cache_expires_at = 0.0
+
+        import unittest.mock as mock
+        with mock.patch("requests.get", side_effect=AssertionError("requests.get called during pause")):
+            import ingestion.ev_sector as ev
+            result = ev.get_ev_sector_intel()
+
+        assert result is None
+
+
+class TestInstitutionalSilence:
+    def test_get_institutional_intel_returns_none_when_paused(self, monkeypatch, tmp_path):
+        _force_paused(monkeypatch, tmp_path)
+        import pause_guard as pg
+        pg._cache_expires_at = 0.0
+
+        import unittest.mock as mock
+        with mock.patch("requests.get", side_effect=AssertionError("requests.get called during pause")):
+            import ingestion.institutional as inst
+            result = inst.get_institutional_intel()
+
+        assert result is None
+
+
+class TestMacroRegimeSilence:
+    def test_get_macro_regime_returns_none_when_paused(self, monkeypatch, tmp_path):
+        _force_paused(monkeypatch, tmp_path)
+        import pause_guard as pg
+        pg._cache_expires_at = 0.0
+
+        import unittest.mock as mock
+        with mock.patch("requests.get", side_effect=AssertionError("requests.get called during pause")):
+            import ingestion.macro_regime as mr
+            result = mr.get_macro_regime()
+
+        assert result is None
+
+
+class TestTradierChainSilence:
+    def test_get_expirations_returns_none_when_paused(self, monkeypatch, tmp_path):
+        _force_paused(monkeypatch, tmp_path)
+        import pause_guard as pg
+        pg._cache_expires_at = 0.0
+
+        import unittest.mock as mock
+        with mock.patch("requests.get", side_effect=AssertionError("requests.get called during pause")):
+            import ingestion.tradier_chain as tc
+            result = tc.get_expirations()
+
+        assert result is None
+
+    def test_get_chain_returns_none_when_paused(self, monkeypatch, tmp_path):
+        _force_paused(monkeypatch, tmp_path)
+        import pause_guard as pg
+        pg._cache_expires_at = 0.0
+
+        import unittest.mock as mock
+        with mock.patch("requests.get", side_effect=AssertionError("requests.get called during pause")):
+            import ingestion.tradier_chain as tc
+            result = tc.get_chain("TSLA", "2026-04-25")
+
+        assert result is None
+
+
+class TestPremarketSilence:
+    def test_fetch_premarket_returns_none_when_paused(self, monkeypatch, tmp_path):
+        _force_paused(monkeypatch, tmp_path)
+        import pause_guard as pg
+        pg._cache_expires_at = 0.0
+
+        import unittest.mock as mock
+        with mock.patch("requests.get", side_effect=AssertionError("requests.get called during pause")):
+            import ingestion.premarket as pm
+            result = pm._fetch_premarket()
+
+        assert result is None
+
+
+class TestPauseGuardCacheInvalidation:
+    """Verify the 500ms TTL cache is correctly invalidated."""
+
+    def test_cache_expires_after_ttl(self, tmp_path):
+        import pause_guard as pg
+
+        # Start with a paused state
+        pf = tmp_path / "pause.json"
+        pf.write_text(json.dumps({"paused": True, "unpause_until": None}))
+        old_file = pg.PAUSE_STATE_FILE
+        pg.PAUSE_STATE_FILE = str(pf)
+        pg._cache_expires_at = 0.0
+
+        try:
+            assert pg.is_paused() is True, "Should be paused"
+
+            # Now switch to unpaused
+            import datetime
+            future = (datetime.datetime.now(datetime.timezone.utc) +
+                      datetime.timedelta(hours=1)).isoformat()
+            pf.write_text(json.dumps({"paused": False, "unpause_until": future}))
+
+            # Cache still reports paused
+            assert pg.is_paused() is True, "Cache should still report paused within TTL"
+
+            # Expire the cache manually
+            pg._cache_expires_at = 0.0
+            assert pg.is_paused() is False, "After cache expiry, should read new file"
+        finally:
+            pg.PAUSE_STATE_FILE = old_file
+            pg._cache_expires_at = 0.0

--- a/tcode/alpha_engine/tests/test_pause_socket_guard.py
+++ b/tcode/alpha_engine/tests/test_pause_socket_guard.py
@@ -1,0 +1,153 @@
+"""
+test_pause_socket_guard.py — Phase 21: socket-level network blocking tests.
+
+Verifies that socket_guard.py:
+  - Blocks non-whitelisted outbound connections when paused
+  - Allows whitelisted connections (localhost:4222 NATS, localhost:4002 IBKR) when paused
+  - Allows all connections when NOT paused
+  - install_socket_guard() is idempotent (safe to call twice)
+  - uninstall_socket_guard() restores the original function
+"""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sys
+import unittest.mock as mock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import socket_guard as sg
+from socket_guard import PausedNetworkError
+
+
+@pytest.fixture(autouse=True)
+def _reset_guard():
+    """Ensure socket guard is uninstalled before and after each test."""
+    sg.uninstall_socket_guard()
+    yield
+    sg.uninstall_socket_guard()
+
+
+@pytest.fixture()
+def paused_state(tmp_path, monkeypatch):
+    """Point pause_guard at a paused state file and invalidate its cache."""
+    import pause_guard as pg
+    pf = tmp_path / "pause.json"
+    pf.write_text(json.dumps({"paused": True, "unpause_until": None}))
+    monkeypatch.setenv("PUBLISHER_PAUSE_STATE_FILE", str(pf))
+    old_file = pg.PAUSE_STATE_FILE
+    pg.PAUSE_STATE_FILE = str(pf)
+    pg._cache_expires_at = 0.0
+    yield str(pf)
+    pg.PAUSE_STATE_FILE = old_file
+    pg._cache_expires_at = 0.0
+
+
+@pytest.fixture()
+def unpaused_state(tmp_path, monkeypatch):
+    """Point pause_guard at an unpaused state file."""
+    import pause_guard as pg
+    import datetime
+    pf = tmp_path / "pause.json"
+    future = (datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1)).isoformat()
+    pf.write_text(json.dumps({"paused": False, "unpause_until": future}))
+    monkeypatch.setenv("PUBLISHER_PAUSE_STATE_FILE", str(pf))
+    old_file = pg.PAUSE_STATE_FILE
+    pg.PAUSE_STATE_FILE = str(pf)
+    pg._cache_expires_at = 0.0
+    yield str(pf)
+    pg.PAUSE_STATE_FILE = old_file
+    pg._cache_expires_at = 0.0
+
+
+class TestSocketGuardInstallation:
+    def test_install_is_idempotent(self):
+        sg.install_socket_guard()
+        first = socket.create_connection
+        sg.install_socket_guard()   # second call should not change anything
+        assert socket.create_connection is first
+
+    def test_uninstall_restores_original(self):
+        original = sg._original_create_connection
+        sg.install_socket_guard()
+        assert socket.create_connection is not original
+        sg.uninstall_socket_guard()
+        assert socket.create_connection is original
+
+    def test_guard_installed_flag(self):
+        assert sg._guard_installed is False
+        sg.install_socket_guard()
+        assert sg._guard_installed is True
+        sg.uninstall_socket_guard()
+        assert sg._guard_installed is False
+
+
+class TestSocketGuardBlocking:
+    def test_blocks_external_host_when_paused(self, paused_state):
+        sg.install_socket_guard()
+        with pytest.raises(PausedNetworkError) as exc_info:
+            socket.create_connection(("api.tradier.com", 443))
+        assert "blocked" in str(exc_info.value).lower()
+        assert "api.tradier.com" in str(exc_info.value)
+
+    def test_blocks_yfinance_host_when_paused(self, paused_state):
+        sg.install_socket_guard()
+        with pytest.raises(PausedNetworkError):
+            socket.create_connection(("query1.finance.yahoo.com", 443))
+
+    def test_blocks_any_non_whitelisted_port_when_paused(self, paused_state):
+        sg.install_socket_guard()
+        with pytest.raises(PausedNetworkError):
+            socket.create_connection(("localhost", 8080))
+
+
+class TestSocketGuardWhitelist:
+    def _try_connect(self, host: str, port: int):
+        """Attempt a connection and return any exception raised (or None if succeeded)."""
+        try:
+            conn = socket.create_connection((host, port), timeout=0.05)
+            conn.close()
+            return None
+        except PausedNetworkError:
+            raise  # re-raise to let the test catch it
+        except Exception:
+            return None  # connection refused / timeout is expected in test env
+
+    def test_allows_nats_localhost_when_paused(self, paused_state):
+        """localhost:4222 (NATS) must not be blocked by PausedNetworkError."""
+        sg.install_socket_guard()
+        # Should not raise PausedNetworkError — may succeed or fail with OSError
+        self._try_connect("localhost", 4222)
+
+    def test_allows_nats_127_when_paused(self, paused_state):
+        """127.0.0.1:4222 (NATS) must not be blocked by PausedNetworkError."""
+        sg.install_socket_guard()
+        self._try_connect("127.0.0.1", 4222)
+
+    def test_allows_ibkr_localhost_when_paused(self, paused_state):
+        """localhost:4002 (IBKR gateway) must not be blocked by PausedNetworkError."""
+        sg.install_socket_guard()
+        self._try_connect("localhost", 4002)
+
+
+class TestSocketGuardPassThrough:
+    def test_allows_external_connections_when_not_paused(self, unpaused_state):
+        """When system is NOT paused, guard is transparent — delegate to original."""
+        sg.install_socket_guard()
+        original_calls = []
+        with mock.patch.object(
+            sg, "_original_create_connection",
+            side_effect=lambda *a, **kw: original_calls.append(a)
+        ):
+            try:
+                socket.create_connection(("api.tradier.com", 443), timeout=0.01)
+            except Exception:
+                pass   # connection will fail in test env, that's fine
+
+        assert len(original_calls) == 1, (
+            "When unpaused, _original_create_connection should be called once"
+        )

--- a/tcode/execution_engine/api.go
+++ b/tcode/execution_engine/api.go
@@ -2735,6 +2735,29 @@ func (h *ConfigHandler) ServeSystemAlerts(w http.ResponseWriter, r *http.Request
 	w.Write(out)
 }
 
+// ServeSystemAuditFeed handles GET /api/system/audit-feed — recent system audit events.
+//
+// Returns an array of AuditEntry objects [{ts, level, message, source}] derived from
+// the last N lines of the system alert stream.  Accepts ?limit=N (default 50, max 200).
+// Returns [] when no data is available so the frontend ActivityTab degrades gracefully.
+func (h *ConfigHandler) ServeSystemAuditFeed(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	// Delegate to the same heartbeat_query.py that ServeSystemAlerts uses.
+	cmd := exec.Command("./alpha_engine/venv/bin/python",
+		"alpha_engine/heartbeat_query.py", "alerts")
+	cmd.Dir = "/home/builder/src/gpfiles/tcode"
+	cmd.Env = os.Environ()
+
+	out, err := cmd.Output()
+	if err != nil || len(out) == 0 {
+		w.Write([]byte("[]"))
+		return
+	}
+	w.Write(out)
+}
+
 // ServeSignalRejections handles GET /api/signals/rejections — paginated + filtered list.
 //
 //	Query params: since, hours (default 24), limit (default 50), offset (default 0),

--- a/tcode/execution_engine/main.go
+++ b/tcode/execution_engine/main.go
@@ -189,7 +189,6 @@ func main() {
 	mux.HandleFunc("/api/signals/all", configHandler.ServeAllSignals)
 	mux.HandleFunc("/api/simulation", configHandler.ServeSimulation)
 	mux.HandleFunc("/api/simulation/toggle", configHandler.ToggleSimulation)
-	mux.HandleFunc("/api/guard/reset", configHandler.ResetGuard)
 	mux.HandleFunc("/api/portfolio", configHandler.ServePortfolio)
 	mux.HandleFunc("/api/trades", configHandler.ServeTrades)
 	mux.HandleFunc("/api/metrics/requests", configHandler.ServeRequestMetrics)

--- a/tcode/execution_engine/main.go
+++ b/tcode/execution_engine/main.go
@@ -277,6 +277,8 @@ func main() {
 	// System heartbeats (Phase 13.6)
 	mux.HandleFunc("/api/system/heartbeats", configHandler.ServeSystemHeartbeats)
 	mux.HandleFunc("/api/system/alerts", configHandler.ServeSystemAlerts)
+	// Phase 21: audit activity feed (TabbedReferencePanel ActivityTab)
+	mux.HandleFunc("/api/system/audit-feed", configHandler.ServeSystemAuditFeed)
 	// Prefix-match for /{component}/sparkline and /{component}/restart
 	mux.HandleFunc("/api/system/heartbeats/", func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
@@ -294,10 +296,18 @@ func main() {
 	mux.HandleFunc("/dev/reload", TriggerReloadHandler)
 
 	// Serve Production UI Assets (Task: Unified Port Stability)
-	// SPA fallback: serve index.html for unknown paths (React Router client-side routing)
+	// SPA fallback: serve index.html for unknown paths (React Router client-side routing).
+	// Guard: /api/* paths that reach this handler have no registered handler — return 404 JSON
+	// instead of serving index.html, which would cause the frontend to try to JSON.parse HTML.
 	uiPath := "./alpha_control_center/dist"
 	fileServer := http.FileServer(http.Dir(uiPath))
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/") {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"error":"api endpoint not found","path":"` + r.URL.Path + `"}`))
+			return
+		}
 		path := uiPath + r.URL.Path
 		if _, err := os.Stat(path); os.IsNotExist(err) {
 			http.ServeFile(w, r, uiPath+"/index.html")

--- a/tcode/execution_engine/main.go
+++ b/tcode/execution_engine/main.go
@@ -270,6 +270,8 @@ func main() {
 	mux.HandleFunc("/api/system/pause-status", configHandler.ServePauseStatus)
 	mux.HandleFunc("/api/system/pause", configHandler.ServePause)
 	mux.HandleFunc("/api/system/unpause", configHandler.ServeUnpause)
+	// Phase 21: pause leak watchdog status (pause_leak_detector.py daemon output)
+	mux.HandleFunc("/api/pause/watchdog-status", configHandler.ServeWatchdogStatus)
 
 	// Phase 19: Guard circuit breaker reset (market-hours confirmation required)
 	mux.HandleFunc("/api/guard/reset", configHandler.ServeGuardReset)

--- a/tcode/execution_engine/main_routes_test.go
+++ b/tcode/execution_engine/main_routes_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"regexp"
+	"testing"
+)
+
+// TestNoDuplicateRoutes scans main.go for mux.Handle / mux.HandleFunc registrations
+// and fails if any route pattern appears more than once.
+//
+// Background: Go 1.25 ServeMux panics at startup when the same pattern is
+// registered twice. This happened in Phase 21 when /api/guard/reset was
+// registered by both ResetGuard (Phase 16 stub) and ServeGuardReset (Phase 19).
+// This test ensures that regression cannot silently re-enter the codebase.
+func TestNoDuplicateRoutes(t *testing.T) {
+	f, err := os.Open("main.go")
+	if err != nil {
+		t.Fatalf("cannot open main.go: %v", err)
+	}
+	defer f.Close()
+
+	// Match: mux.Handle("…") or mux.HandleFunc("…", …)
+	re := regexp.MustCompile(`mux\.Handle(?:Func)?\("([^"]+)"`)
+
+	seen := make(map[string]int) // pattern → first line number
+	seenLine := make(map[string]int)
+
+	scanner := bufio.NewScanner(f)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := scanner.Text()
+		m := re.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		pattern := m[1]
+		if prev, dup := seenLine[pattern]; dup {
+			t.Errorf(
+				"duplicate route %q: first registered at line %d, re-registered at line %d — "+
+					"Go 1.25 ServeMux panics on startup when the same pattern is registered twice",
+				pattern, prev, lineNum,
+			)
+		} else {
+			seenLine[pattern] = lineNum
+			seen[pattern]++
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scanner error: %v", err)
+	}
+
+	t.Logf("checked %d unique route registrations, no duplicates found", len(seen))
+}

--- a/tcode/execution_engine/pause_api.go
+++ b/tcode/execution_engine/pause_api.go
@@ -140,3 +140,27 @@ func (ch *ConfigHandler) ServeUnpause(w http.ResponseWriter, r *http.Request) {
 	resp := pauseStatusResponse{Paused: false, UnpauseUntil: &untilStr, RemainingSec: rem}
 	_ = json.NewEncoder(w).Encode(resp)
 }
+
+// watchdogStatusFile is where pause_leak_detector.py writes its status JSON.
+const watchdogStatusFile = "/tmp/pause_watchdog_status.json"
+
+// ServeWatchdogStatus handles GET /api/pause/watchdog-status.
+//
+// Reads /tmp/pause_watchdog_status.json written by the pause_leak_detector.py
+// daemon and returns it verbatim. Returns a safe default {"ok":true,"leak_count":0}
+// when the daemon hasn't written the file yet (e.g. right after startup).
+func (ch *ConfigHandler) ServeWatchdogStatus(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	if r.Method != http.MethodGet {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+	data, err := os.ReadFile(watchdogStatusFile)
+	if err != nil {
+		// Daemon not yet running or file not written — safe default
+		w.Write([]byte(`{"ok":true,"paused":false,"leak_count":0,"leaks":[],"last_checked":0}`))
+		return
+	}
+	w.Write(data)
+}


### PR DESCRIPTION
## Summary

- **Site-down hotfix (Commit 1):** Removed duplicate `/api/guard/reset` route that caused Go 1.25 ServeMux to panic on startup. Phase 19 added `ServeGuardReset` without removing the `ResetGuard` stub from Phase 16.

- **Regression test (Commit 2):** `main_routes_test.go` — AST-scans `main.go` for duplicate `mux.Handle*` patterns; fails the build if anyone re-introduces a duplicate route.

- **Precursor hotfix (Commit 3):**
  - SPA fallback now returns 404 JSON for `/api/*` paths instead of serving `index.html` (prevents HTML from being JSON-parsed and crashing `.map()` calls)
  - Added `/api/system/audit-feed` endpoint for the `TabbedReferencePanel` ActivityTab
  - Fixed `MergedPositionsTable` cancel URL: `POST /api/orders/${id}/cancel` → `POST /api/orders/cancel` with `order_id` in body

- **Phase 21 core (Commit 4):** Bulletproof pause-means-silent guarantee:

### pause_guard.py
- `is_paused()` with 500ms TTL cache (avoids disk thrash)
- `@pause_guard` / `@pause_guard_async` decorators that return `None` immediately and append a JSONL record to `/tmp/pause_blocks.jsonl`

### socket_guard.py
- Monkeypatches `socket.create_connection` when installed
- Blocks all non-whitelisted outbound TCP when paused
- **Whitelist:** `localhost:4222` (NATS heartbeat), `localhost:4002` (IBKR gateway)

### @pause_guard applied to 8 ingestion modules (10 functions)
`catalyst_tracker`, `ev_sector`, `institutional`, `macro_regime`, `intel`, `tradier_chain` (3 fns), `premarket`, `congress_trades` (2 fns)

### Tests — 30 new, all passing
- `test_pause_guard_coverage.py` (12): AST-based contract — fails build if any guarded module loses its decorator
- `test_pause_silence.py` (8): zero `requests.get` when paused
- `test_pause_socket_guard.py` (10): socket blocking + whitelist pass-through

### pause_leak_detector.py daemon
- `AlertThrottle(window_sec=600)` — first alert immediate, batched digest after 10 min
- Writes `/tmp/pause_watchdog_status.json` every 30s

### Go: `/api/pause/watchdog-status`
Reads `/tmp/pause_watchdog_status.json`; safe default `{"ok":true}` when daemon not running.

### Frontend: `PauseWatchdogBadge.tsx`
Polls watchdog status every 10s. Shown in nav bar next to PauseCountdown.

## Test plan
- [x] `go build ./...` — no errors
- [x] `TestNoDuplicateRoutes` — 77 unique routes, none duplicated
- [x] Python: 30/30 pause guard tests pass
- [x] TypeScript: `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
